### PR TITLE
fix: correctly return custom maven invocation error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.23.2",
 				"@openapitools/openapi-generator-cli": "^2.6.0",
-				"@types/node": "^20.3.1",
+				"@types/node": "^20.17.30",
 				"babel-plugin-rewire": "^1.2.0",
 				"c8": "^8.0.0",
 				"chai": "^4.3.7",
@@ -1099,9 +1099,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.3.1",
+			"version": "20.17.30",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
+			"integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.19.2"
+			}
 		},
 		"node_modules/@types/set-cookie-parser": {
 			"version": "2.4.2",
@@ -4452,6 +4457,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/universalify": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.23.2",
 		"@openapitools/openapi-generator-cli": "^2.6.0",
-		"@types/node": "^20.3.1",
+		"@types/node": "^20.17.30",
 		"babel-plugin-rewire": "^1.2.0",
 		"c8": "^8.0.0",
 		"chai": "^4.3.7",

--- a/src/providers/base_java.js
+++ b/src/providers/base_java.js
@@ -1,5 +1,5 @@
-import {execSync} from "node:child_process"
-import {PackageURL} from 'packageurl-js'
+import { execFileSync, execSync } from "node:child_process"
+import { PackageURL } from 'packageurl-js'
 
 
 /** @typedef {import('../provider').Provider} */
@@ -17,21 +17,16 @@ import {PackageURL} from 'packageurl-js'
 export const ecosystem_maven = 'maven'
 export const ecosystem_gradle = 'gradle'
 export default class Base_Java {
-	constructor() {
-	}
-
-
-
 	DEP_REGEX = /(([-a-zA-Z0-9._]{2,})|[0-9])/g
 	CONFLICT_REGEX = /.*omitted for conflict with (\S+)\)/
 
 	/**
- * Recursively populates the SBOM instance with the parsed graph
- * @param {string} src - Source dependency to start the calculations from
- * @param {number} srcDepth - Current depth in the graph for the given source
- * @param {Array} lines - Array containing the text files being parsed
- * @param {Sbom} sbom - The SBOM where the dependencies are being added
- */
+	 * Recursively populates the SBOM instance with the parsed graph
+	 * @param {string} src - Source dependency to start the calculations from
+	 * @param {number} srcDepth - Current depth in the graph for the given source
+	 * @param {Array} lines - Array containing the text files being parsed
+	 * @param {Sbom} sbom - The SBOM where the dependencies are being added
+	 */
 	parseDependencyTree(src, srcDepth, lines, sbom) {
 		if (lines.length === 0) {
 			return;
@@ -61,11 +56,11 @@ export default class Base_Java {
 	}
 
 	/**
- * Calculates how deep in the graph is the given line
- * @param {string} line - line to calculate the depth from
- * @returns {number} The calculated depth
- * @private
- */
+	 * Calculates how deep in the graph is the given line
+	 * @param {string} line - line to calculate the depth from
+	 * @returns {number} The calculated depth
+	 * @private
+	 */
 	#getDepth(line) {
 		if (line === undefined) {
 			return -1;
@@ -74,10 +69,10 @@ export default class Base_Java {
 	}
 
 	/**
- * Create a PackageURL from any line in a Text Graph dependency tree for a manifest path.
- * @param {string} line - line to parse from a dependencies.txt file
- * @returns {PackageURL} The parsed packageURL
- */
+	 * Create a PackageURL from any line in a Text Graph dependency tree for a manifest path.
+	 * @param {string} line - line to parse from a dependencies.txt file
+	 * @returns {PackageURL} The parsed packageURL
+	 */
 	parseDep(line) {
 
 		let match = line.match(this.DEP_REGEX);
@@ -98,12 +93,12 @@ export default class Base_Java {
 	}
 
 	/**
- * Returns a PackageUrl For Java maven dependencies
- * @param group
- * @param artifact
- * @param version
- * @return {PackageURL}
- */
+	 * Returns a PackageUrl For Java maven dependencies
+	 * @param group
+	 * @param artifact
+	 * @param version
+	 * @return {PackageURL}
+	 */
 	toPurl(group, artifact, version) {
 		if (typeof version === "number") {
 			version = version.toString()
@@ -112,16 +107,17 @@ export default class Base_Java {
 	}
 
 	/** this method invokes command string in a process in a synchronous way.
-	 * @param cmdString - the command to be invoked
-	 * @param errorMessage - the message to print to an exception thrown to client in case of error
+	 * @param bin - the command to be invoked
+	 * @param args - the args to pass to the binary
+	 * @param callback - function to invoke if an error was thrown
 	 * @protected
 	 */
-	_invokeCommand(cmdString, errorMessage) {
-		execSync(cmdString, err => {
-			if (err) {
-				throw new Error(`${errorMessage}`)
-			}
-		})
+	_invokeCommand(bin, args, callback) {
+		try {
+			execFileSync(bin, args)
+		} catch(error) {
+			callback(error)
+		}
 	}
 
 	/** this method invokes command string in a process in a synchronous way.
@@ -137,6 +133,4 @@ export default class Base_Java {
 		}
 		return execSync(cmdString, opts)
 	}
-
-
 }

--- a/src/providers/base_java.js
+++ b/src/providers/base_java.js
@@ -1,5 +1,5 @@
 import { PackageURL } from 'packageurl-js'
-import { invokeCommand, invokeCommandGetOutput } from "../tools.js"
+import { invokeCommand } from "../tools.js"
 
 
 /** @typedef {import('../provider').Provider} */
@@ -112,13 +112,5 @@ export default class Base_Java {
 	 * @param callback - function to invoke if an error was thrown
 	 * @protected
 	 */
-	_invokeCommand(bin, args, callback) { invokeCommand(bin, args, callback) }
-
-	/** this method invokes command string in a process in a synchronous way.
-	 * @param cmdString - the command to be invoked
-	 * @param workingDir - the directory in which the command will be invoked
-	 * @return the output of the command
-	 * @protected
-	 */
-	_invokeCommandGetOutput(cmdString, workingDir) { return invokeCommandGetOutput(cmdString, workingDir) }
+	_invokeCommand(bin, args, callback, opts={}) { return invokeCommand(bin, args, callback, opts) }
 }

--- a/src/providers/base_java.js
+++ b/src/providers/base_java.js
@@ -1,5 +1,5 @@
-import { execFileSync, execSync } from "node:child_process"
 import { PackageURL } from 'packageurl-js'
+import { invokeCommand, invokeCommandGetOutput } from "../tools.js"
 
 
 /** @typedef {import('../provider').Provider} */
@@ -112,13 +112,7 @@ export default class Base_Java {
 	 * @param callback - function to invoke if an error was thrown
 	 * @protected
 	 */
-	_invokeCommand(bin, args, callback) {
-		try {
-			execFileSync(bin, args)
-		} catch(error) {
-			callback(error)
-		}
-	}
+	_invokeCommand(bin, args, callback) { invokeCommand(bin, args, callback) }
 
 	/** this method invokes command string in a process in a synchronous way.
 	 * @param cmdString - the command to be invoked
@@ -126,11 +120,5 @@ export default class Base_Java {
 	 * @return the output of the command
 	 * @protected
 	 */
-	_invokeCommandGetOutput(cmdString, workingDir) {
-		let opts = {}
-		if(workingDir) {
-			opts.cwd = workingDir
-		}
-		return execSync(cmdString, opts)
-	}
+	_invokeCommandGetOutput(cmdString, workingDir) { return invokeCommandGetOutput(cmdString, workingDir) }
 }

--- a/src/providers/java_gradle.js
+++ b/src/providers/java_gradle.js
@@ -199,7 +199,7 @@ export default class Java_gradle extends Base_java {
 		let gradle = getCustomPath("gradle", opts);
 		let properties
 		properties = this._invokeCommand(gradle, ['properties'], error => {
-			throw new Error(`Couldn't get properties of ${this._getManifestName()} file , Error message returned from gradle binary => ${EOL} ${error.getMessage}`)
+			throw new Error(`Couldn't get properties of ${this._getManifestName()} file , Error message returned from gradle binary => ${EOL} ${error.message}`)
 		}, {
 			cwd: path.dirname(manifestPath)
 		})
@@ -242,7 +242,7 @@ export default class Java_gradle extends Base_java {
 	#getDependencies(manifest) {
 		const gradle = getCustomPath("gradle")
 		const commandResult = this._invokeCommand(gradle, ['dependencies'], error => {
-			throw new Error(`Couldn't run gradle dependencies command, error message returned from gradle binary => ${EOL} ${error.getMessage}`)
+			throw new Error(`Couldn't run gradle dependencies command, error message returned from gradle binary => ${EOL} ${error.message}`)
 		}, {
 			cwd: path.dirname(manifest)
 		})

--- a/src/providers/java_gradle.js
+++ b/src/providers/java_gradle.js
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import {getCustomPath, handleSpacesInPath} from "../tools.js";
+import {getCustomPath} from "../tools.js";
 import path from 'node:path'
 import Sbom from '../sbom.js'
 import {EOL} from 'os'
@@ -198,11 +198,11 @@ export default class Java_gradle extends Base_java {
 	#getProperties(manifestPath, opts) {
 		let gradle = getCustomPath("gradle", opts);
 		let properties
-		try {
-			properties = this._invokeCommandGetOutput(`${handleSpacesInPath(gradle)} properties`, path.dirname(manifestPath))
-		} catch (e) {
-			throw new Error(`Couldn't get properties of ${this._getManifestName()} file , Error message returned from gradle binary => ${EOL} ${e.getMessage}`)
-		}
+		properties = this._invokeCommand(gradle, ['properties'], error => {
+			throw new Error(`Couldn't get properties of ${this._getManifestName()} file , Error message returned from gradle binary => ${EOL} ${error.getMessage}`)
+		}, {
+			cwd: path.dirname(manifestPath)
+		})
 		return properties.toString()
 	}
 
@@ -240,14 +240,12 @@ export default class Java_gradle extends Base_java {
 	 */
 
 	#getDependencies(manifest) {
-		let gradle
-		let commandResult
-		gradle = getCustomPath("gradle")
-		try {
-			commandResult = this._invokeCommandGetOutput(`${handleSpacesInPath(gradle)} dependencies`, path.dirname(manifest))
-		} catch (e) {
-			throw new Error(`Couldn't run gradle dependencies command, error message returned from gradle binary => ${EOL} ${e.getMessage}`)
-		}
+		const gradle = getCustomPath("gradle")
+		const commandResult = this._invokeCommand(gradle, ['dependencies'], error => {
+			throw new Error(`Couldn't run gradle dependencies command, error message returned from gradle binary => ${EOL} ${error.getMessage}`)
+		}, {
+			cwd: path.dirname(manifest)
+		})
 		return commandResult.toString()
 	}
 

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -78,12 +78,12 @@ export default class Java_maven extends Base_java {
 			if (error.code === 'ENOENT') {
 				throw new Error(`maven not accessible at "${mvn}"`)
 			} else {
-				throw new Error(`failed to check for maven: ${error.stderr}`)
+				throw new Error(`failed to check for maven`, {cause: error})
 			}
 		})
 		// clean maven target
 		this._invokeCommand(mvn, ['-q', 'clean', '-f', manifest], error => {
-			throw new Error(`failed to clean maven target: ${error.stderr}`)
+			throw new Error(`failed to clean maven target`, {cause: error})
 		})
 
 		// create dependency graph in a temp file
@@ -102,7 +102,7 @@ export default class Java_maven extends Base_java {
 		})
 		// execute dependency tree command
 		this._invokeCommand(mvn, depTreeCmdArgs, error => {
-			throw new Error(`failed creating maven dependency tree: ${error.stderr}`)
+			throw new Error(`failed creating maven dependency tree`, {cause: error})
 		})
 		// read dependency tree from temp file
 		let content = fs.readFileSync(`${tmpDepTree}`)
@@ -149,7 +149,7 @@ export default class Java_maven extends Base_java {
 			if (error.code === 'ENOENT') {
 				throw new Error(`maven not accessible at "${mvn}"`)
 			} else {
-				throw new Error(`failed to check for maven: ${error.stderr}`)
+				throw new Error(`failed to check for maven`, {cause: error})
 			}
 		})
 		// create temp files for pom and effective pom
@@ -170,7 +170,7 @@ export default class Java_maven extends Base_java {
 
 		// create effective pom and save to temp file
 		this._invokeCommand(mvn, ['-q', 'help:effective-pom', `-Doutput=${tmpEffectivePom}`, '-f', targetPom], error => {
-			throw new Error(`failed creating maven effective pom: ${error.stderr}`)
+			throw new Error(`failed creating maven effective pom`, {cause: error})
 		})
 		// iterate over all dependencies in original pom and collect all ignored ones
 		let ignored = this.#getDependencies(targetPom).filter(d => d.ignore)

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -1,12 +1,11 @@
-import {XMLParser} from 'fast-xml-parser'
+import { XMLParser } from 'fast-xml-parser'
 import fs from 'node:fs'
-import {getCustomPath,handleSpacesInPath} from "../tools.js";
+import { getCustomPath } from "../tools.js";
 import os from 'node:os'
 import path from 'node:path'
 import Sbom from '../sbom.js'
-import {EOL} from 'os'
-import Base_java, {ecosystem_maven} from "./base_java.js";
-
+import { EOL } from 'os'
+import Base_java, { ecosystem_maven } from "./base_java.js";
 
 
 /** @typedef {import('../provider').Provider} */
@@ -16,8 +15,6 @@ import Base_java, {ecosystem_maven} from "./base_java.js";
 /** @typedef {{name: string, version: string}} Package */
 
 /** @typedef {{groupId: string, artifactId: string, version: string, scope: string, ignore: boolean}} Dependency */
-
-
 
 export default class Java_maven extends Base_java {
 
@@ -77,25 +74,36 @@ export default class Java_maven extends Base_java {
 		// get custom maven path
 		let mvn = getCustomPath('mvn', opts)
 		// verify maven is accessible
-		this._invokeCommand(`${handleSpacesInPath(mvn)} --version`,'mvn is not accessible')
+		this._invokeCommand(mvn, ['--version'], error => {
+			if (error.code === 'ENOENT') {
+				throw new Error(`maven not accessible at "${mvn}"`)
+			} else {
+				throw new Error(`failed to check for maven: ${error.stderr}`)
+			}
+		})
 		// clean maven target
-		this._invokeCommand(`${handleSpacesInPath(mvn)} -q clean -f ${handleSpacesInPath(manifest)}`,'failed cleaning maven target')
+		this._invokeCommand(mvn, ['-q', 'clean', '-f', manifest], error => {
+			throw new Error(`failed to clean maven target: ${error.stderr}`)
+		})
+
 		// create dependency graph in a temp file
 		let tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exhort_'))
 		let tmpDepTree = path.join(tmpDir, 'mvn_deptree.txt')
 		// build initial command (dot outputType is not available for verbose mode)
-		let depTreeCmd = `${handleSpacesInPath(mvn)} -q org.apache.maven.plugins:maven-dependency-plugin:3.6.0:tree -Dverbose -DoutputType=text -DoutputFile=${handleSpacesInPath(tmpDepTree)} -f ${handleSpacesInPath(manifest)}`
+		let depTreeCmdArgs = ['-q', 'org.apache.maven.plugins:maven-dependency-plugin:3.6.0:tree', '-Dverbose', '-DoutputType=text', `-DoutputFile=${tmpDepTree}`, '-f', manifest]
 		// exclude ignored dependencies, exclude format is groupId:artifactId:scope:version.
 		// version and scope are marked as '*' if not specified (we do not use scope yet)
 		let ignoredDeps = new Array()
 		this.#getDependencies(manifest).forEach(dep => {
 			if (dep.ignore) {
-				depTreeCmd += ` -Dexcludes=${dep['groupId']}:${dep['artifactId']}:${dep['scope']}:${dep['version']}`
+				depTreeCmdArgs.push(`-Dexcludes=${dep['groupId']}:${dep['artifactId']}:${dep['scope']}:${dep['version']}`)
 				ignoredDeps.push(this.toPurl(dep.groupId, dep.artifactId, dep.version).toString())
 			}
 		})
 		// execute dependency tree command
-		this._invokeCommand(depTreeCmd,"failed creating maven dependency tree");
+		this._invokeCommand(mvn, depTreeCmdArgs, error => {
+			throw new Error(`failed creating maven dependency tree: ${error.stderr}`)
+		})
 		// read dependency tree from temp file
 		let content = fs.readFileSync(`${tmpDepTree}`)
 		if (process.env["EXHORT_DEBUG"] === "true") {
@@ -137,7 +145,13 @@ export default class Java_maven extends Base_java {
 		// get custom maven path
 		let mvn = getCustomPath('mvn', opts)
 		// verify maven is accessible
-		this._invokeCommand(`${handleSpacesInPath(mvn)} --version`,'mvn is not accessible')
+		this._invokeCommand(mvn, ['--version'], error => {
+			if (error.code === 'ENOENT') {
+				throw new Error(`maven not accessible at "${mvn}"`)
+			} else {
+				throw new Error(`failed to check for maven: ${error.stderr}`)
+			}
+		})
 		// create temp files for pom and effective pom
 		let tmpDir
 		let tmpEffectivePom
@@ -155,7 +169,9 @@ export default class Java_maven extends Base_java {
 		}
 
 		// create effective pom and save to temp file
-		this._invokeCommand(`${handleSpacesInPath(mvn)} -q help:effective-pom -Doutput=${handleSpacesInPath(tmpEffectivePom)} -f ${handleSpacesInPath(targetPom)}`,'failed creating maven effective pom')
+		this._invokeCommand(mvn, ['-q', 'help:effective-pom', `-Doutput=${tmpEffectivePom}`, '-f', targetPom], error => {
+			throw new Error(`failed creating maven effective pom: ${error.stderr}`)
+		})
 		// iterate over all dependencies in original pom and collect all ignored ones
 		let ignored = this.#getDependencies(targetPom).filter(d => d.ignore)
 		// iterate over all dependencies and create a package for every non-ignored one

--- a/src/tools.js
+++ b/src/tools.js
@@ -110,7 +110,9 @@ export function invokeCommand(bin, args, callback, opts={}) {
 	if (process.platform === 'win32' && (bin.endsWith(".bat") || bin.endsWith(".cmd"))) {
 		try {
 			args = args.map(arg => handleSpacesInPath(arg))
-			return execSync(`${handleSpacesInPath(bin)} ${args.join(" ")}`, opts)
+			return execSync(`${handleSpacesInPath(bin)} ${args.join(" ")}`, opts & {
+				stdio: 'pipe'
+			})
 		} catch(error) {
 			callback(error)
 		}
@@ -118,7 +120,9 @@ export function invokeCommand(bin, args, callback, opts={}) {
 	}
 
 	try {
-		return execFileSync(bin, args, opts)
+		return execFileSync(bin, args, opts & {
+			stdio: 'pipe'
+		})
 	} catch(error) {
 		callback(error)
 	}

--- a/src/tools.js
+++ b/src/tools.js
@@ -110,9 +110,7 @@ export function invokeCommand(bin, args, callback, opts={}) {
 	if (process.platform === 'win32' && (bin.endsWith(".bat") || bin.endsWith(".cmd"))) {
 		try {
 			args = args.map(arg => handleSpacesInPath(arg))
-			return execSync(`${handleSpacesInPath(bin)} ${args.join(" ")}`, opts & {
-				stdio: 'pipe'
-			})
+			return execSync(`${handleSpacesInPath(bin)} ${args.join(" ")}`, {...{stdio: 'pipe'}, ...opts})
 		} catch(error) {
 			callback(error)
 		}
@@ -120,9 +118,7 @@ export function invokeCommand(bin, args, callback, opts={}) {
 	}
 
 	try {
-		return execFileSync(bin, args, opts & {
-			stdio: 'pipe'
-		})
+		return execFileSync(bin, args, {...{stdio: 'pipe'}, ...opts})
 	} catch(error) {
 		callback(error)
 	}

--- a/src/tools.js
+++ b/src/tools.js
@@ -103,14 +103,14 @@ function hasSpaces(path) {
  * @param callback - function to invoke if an error was thrown
  * @protected
  */
-export function invokeCommand(bin, args, callback) {
+export function invokeCommand(bin, args, callback, opts={}) {
 	// .bat and .cmd files can't be executed in windows with execFileSync, so we special case them
 	// to use execSync here to keep the amount of escaping we need to do to a minimum.
 	// https://nodejs.org/docs/latest-v20.x/api/child_process.html#spawning-bat-and-cmd-files-on-windows
 	if (process.platform === 'win32' && (bin.endsWith(".bat") || bin.endsWith(".cmd"))) {
 		try {
 			args = args.map(arg => handleSpacesInPath(arg))
-			execSync(`${handleSpacesInPath(bin)} ${args.join(" ")}`)
+			return execSync(`${handleSpacesInPath(bin)} ${args.join(" ")}`, opts)
 		} catch(error) {
 			callback(error)
 		}
@@ -118,22 +118,8 @@ export function invokeCommand(bin, args, callback) {
 	}
 
 	try {
-		execFileSync(bin, args)
+		return execFileSync(bin, args, opts)
 	} catch(error) {
 		callback(error)
 	}
-}
-
-/** this method invokes command string in a process in a synchronous way.
- * @param {string} cmdString - the command to be invoked
- * @param {string} workingDir - the directory in which the command will be invoked
- * @return the output of the command
- * @protected
- */
-export function invokeCommandGetOutput(cmdString, workingDir) {
-	let opts = {}
-	if(workingDir) {
-		opts.cwd = workingDir
-	}
-	return execSync(cmdString, opts)
 }

--- a/test/it/end-to-end.js
+++ b/test/it/end-to-end.js
@@ -76,7 +76,7 @@ suite('Integration Tests', () => {
 				expect(providedDataForStack.scanned.transitive).greaterThan(0)
 			}
 			providers.forEach(provider => expect(providedDataForStack.providers[provider].status.code).equals(200))
-		}).timeout(60000);
+		}).timeout(120000);
 
 		test(`Stack Analysis html for ${packageManager}`, async () => {
 
@@ -114,7 +114,7 @@ suite('Integration Tests', () => {
 				expect(parsedScannedFromHtml.total).greaterThan(0)
 				expect(parsedScannedFromHtml.transitive).greaterThan(0)
 			}
-		}).timeout(30000);
+		}).timeout(60000);
 
 		test(`Component Analysis for ${packageManager}`, async () => {
 			let manifestName = getManifestNamePerPm(packageManager)

--- a/test/providers/java_gradle_groovy.test.js
+++ b/test/providers/java_gradle_groovy.test.js
@@ -7,21 +7,19 @@ let clock
 
 /** this function is parsing the outputfile path from the given command, and write that file the providerContent supplied.
  *
- * @param {string}command - the command string to be executed
+ * @param {Array<string>}args - the args passed to the binary
  * @param {string}providerContent - the content of the mocked data to replace original content in intercepted temp file
  * @param {string} outputFileParameter - name of the parameter indicating the output file of the command invocation, including '='.
  * @private
  */
 
-function getStubbedResponse(command, dependencyTreeTextContent, gradleProperties) {
-	if (command.includes("dependencies")) {
+function getStubbedResponse(args, dependencyTreeTextContent, gradleProperties) {
+	if (args.includes("dependencies")) {
 		return dependencyTreeTextContent
-	} else {
-		if (command.includes("properties")) {
-			return gradleProperties
-		}
+	} else if (args.includes("properties")) {
+		return gradleProperties
 	}
-	return undefined
+	return ''
 }
 
 suite('testing the java-gradle-groovy data provider', () => {
@@ -50,11 +48,11 @@ suite('testing the java-gradle-groovy data provider', () => {
 			let dependencyTreeTextContent = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/depTree.txt`,).toString()
 			let gradleProperties = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/gradle.properties`,).toString()
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
-			let mockedExecFunction = function(command){
-				return getStubbedResponse(command, dependencyTreeTextContent, gradleProperties);
+			let mockedExecFunction = function(bin, args){
+				return getStubbedResponse(args, dependencyTreeTextContent, gradleProperties);
 			}
 			let javGradleProvider = new Java_gradle_groovy()
-			Object.getPrototypeOf(Object.getPrototypeOf(javGradleProvider))._invokeCommandGetOutput = mockedExecFunction
+			Object.getPrototypeOf(Object.getPrototypeOf(javGradleProvider))._invokeCommand = mockedExecFunction
 			// invoke sut stack analysis for scenario manifest
 			let providedDataForStack =  javGradleProvider.provideStack(`test/providers/tst_manifests/gradle/${testCase}/build.gradle`)
 			// verify returned data matches expectation
@@ -76,11 +74,11 @@ suite('testing the java-gradle-groovy data provider', () => {
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
 			let dependencyTreeTextContent = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/depTree.txt`,).toString()
 			let gradleProperties = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/gradle.properties`,).toString()
-			let mockedExecFunction = function(command){
-				return getStubbedResponse(command, dependencyTreeTextContent, gradleProperties);
+			let mockedExecFunction = function(bin, args){
+				return getStubbedResponse(args, dependencyTreeTextContent, gradleProperties);
 			}
 			let javaGradleProvider = new Java_gradle_groovy()
-			Object.getPrototypeOf(Object.getPrototypeOf(javaGradleProvider))._invokeCommandGetOutput = mockedExecFunction
+			Object.getPrototypeOf(Object.getPrototypeOf(javaGradleProvider))._invokeCommand = mockedExecFunction
 			// invoke sut component analysis for scenario manifest
 			let provdidedForComponent = javaGradleProvider.provideComponent("",{},`test/providers/tst_manifests/gradle/${testCase}/build.gradle`)
 			// verify returned data matches expectation

--- a/test/providers/java_gradle_kotlin.test.js
+++ b/test/providers/java_gradle_kotlin.test.js
@@ -7,21 +7,19 @@ let clock
 
 /** this function is parsing the outputfile path from the given command, and write that file the providerContent supplied.
  *
- * @param {string}command - the command string to be executed
+ * @param {Array<string>}args - the args passed to the binary
  * @param {string}providerContent - the content of the mocked data to replace original content in intercepted temp file
  * @param {string} outputFileParameter - name of the parameter indicating the output file of the command invocation, including '='.
  * @private
  */
 
-function getStubbedResponse(command, dependencyTreeTextContent, gradleProperties) {
-	if (command.includes("dependencies")) {
+function getStubbedResponse(args, dependencyTreeTextContent, gradleProperties) {
+	if (args.includes("dependencies")) {
 		return dependencyTreeTextContent
-	} else {
-		if (command.includes("properties")) {
-			return gradleProperties
-		}
+	} else if (args.includes("properties")) {
+		return gradleProperties
 	}
-	return undefined
+	return ''
 }
 
 suite('testing the java-gradle-kotlin data provider', () => {
@@ -50,11 +48,11 @@ suite('testing the java-gradle-kotlin data provider', () => {
 			let dependencyTreeTextContent = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/depTree.txt`,).toString()
 			let gradleProperties = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/gradle.properties`,).toString()
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
-			let mockedExecFunction = function(command){
-				return getStubbedResponse(command, dependencyTreeTextContent, gradleProperties);
+			let mockedExecFunction = function(bin, args){
+				return getStubbedResponse(args, dependencyTreeTextContent, gradleProperties);
 			}
 			let javGradleProvider = new Java_gradle_kotlin()
-			Object.getPrototypeOf(Object.getPrototypeOf(javGradleProvider))._invokeCommandGetOutput = mockedExecFunction
+			Object.getPrototypeOf(Object.getPrototypeOf(javGradleProvider))._invokeCommand = mockedExecFunction
 			// invoke sut stack analysis for scenario manifest
 			let providedDataForStack =  javGradleProvider.provideStack(`test/providers/tst_manifests/gradle/${testCase}/build.gradle.kts`)
 			// verify returned data matches expectation
@@ -76,11 +74,11 @@ suite('testing the java-gradle-kotlin data provider', () => {
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
 			let dependencyTreeTextContent = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/depTree.txt`,).toString()
 			let gradleProperties = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/gradle.properties`,).toString()
-			let mockedExecFunction = function(command){
-				return getStubbedResponse(command, dependencyTreeTextContent, gradleProperties);
+			let mockedExecFunction = function(bin, args){
+				return getStubbedResponse(args, dependencyTreeTextContent, gradleProperties);
 			}
 			let javaGradleProvider = new Java_gradle_kotlin()
-			Object.getPrototypeOf(Object.getPrototypeOf(javaGradleProvider))._invokeCommandGetOutput = mockedExecFunction
+			Object.getPrototypeOf(Object.getPrototypeOf(javaGradleProvider))._invokeCommand = mockedExecFunction
 			// invoke sut component analysis for scenario manifest
 			let provdidedForComponent = javaGradleProvider.provideComponent("",{},`test/providers/tst_manifests/gradle/${testCase}/build.gradle.kts`)
 			// verify returned data matches expectation

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -134,7 +134,7 @@ suite('testing the java-maven data provider with modules', () => {
 			let javaMvnProvider = new Java_maven()
 			Object.getPrototypeOf(Object.getPrototypeOf(javaMvnProvider))._invokeCommand = mockedExecFunction
 			// invoke sut component analysis for scenario manifest
-			let provideDataForComponent = await javaMvnProvider.provideComponent("",{},`test/providers/tst_manifests/maven/${testCase}/pom.xml`)
+			let provideDataForComponent = javaMvnProvider.provideComponent("",{},`test/providers/tst_manifests/maven/${testCase}/pom.xml`)
 			// verify returned data matches expectation
 			expect(provideDataForComponent).to.deep.equal({
 				ecosystem: 'maven',

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -7,17 +7,13 @@ let clock
 
 /** this function is parsing the outputfile path from the given command, and write that file the providerContent supplied.
  *
- * @param {string}command - the command string to be executed
+ * @param {Array<string>}args - the arguments to pass to the binary
  * @param {string}providerContent - the content of the mocked data to replace original content in intercepted temp file
- * @param {string} outputFileParameter - name of the parameter indicating the output file of the command invocation, including '='.
+ * @param {string}outputFileParameter - name of the parameter indicating the output file of the command invocation, including '='.
  * @private
  */
-function interceptAndOverwriteDataWithMock(command, providerContent, outputFileParameter) {
-	let length = outputFileParameter.length;
-	let indexOf = command.indexOf(outputFileParameter);
-	let outputFileTokenPlusRest = command.substring(indexOf + length);
-	let endOfOutputFile = outputFileTokenPlusRest.indexOf("-f");
-	let interceptedFilePath = outputFileTokenPlusRest.substring(0, endOfOutputFile).trim()
+function interceptAndOverwriteDataWithMock(args, providerContent, outputFileParameter) {
+	const interceptedFilePath = args.find(arg => arg.includes(outputFileParameter)).split("=")[1]
 	fs.writeFileSync(interceptedFilePath, providerContent)
 }
 
@@ -67,9 +63,9 @@ suite('testing the java-maven data provider', () => {
 			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/maven/${testCase}/stack_analysis_expected_sbom.json`,).toString().trim()
 			let dependencyTreeTextContent = fs.readFileSync(`test/providers/tst_manifests/maven/${testCase}/dep-tree.txt`,).toString()
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
-			let mockedExecFunction = function(command){
-				if(command.includes(":tree")){
-					interceptAndOverwriteDataWithMock(command,dependencyTreeTextContent,"DoutputFile=")
+			let mockedExecFunction = function(bin, args){
+				if (args.find(arg => arg.includes(":tree"))) {
+					interceptAndOverwriteDataWithMock(args, dependencyTreeTextContent, "DoutputFile=")
 				}
 			}
 			let javaMvnProvider = new Java_maven()
@@ -95,9 +91,9 @@ suite('testing the java-maven data provider', () => {
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
 			let effectivePomContent = fs.readFileSync(`test/providers/tst_manifests/maven/${testCase}/effective-pom.xml`,).toString()
 			let manifestContent = fs.readFileSync(`test/providers/tst_manifests/maven/${testCase}/pom.xml`).toString()
-			let mockedExecFunction = function(command){
-				if(command.includes(":effective-pom")){
-					interceptAndOverwriteDataWithMock(command, effectivePomContent,"Doutput=");
+			let mockedExecFunction = function(bin, args){
+				if (args.find(arg => arg.includes(":effective-pom"))){
+					interceptAndOverwriteDataWithMock(args, effectivePomContent, "Doutput=");
 				}
 			}
 			let javaMvnProvider = new Java_maven()
@@ -130,9 +126,9 @@ suite('testing the java-maven data provider with modules', () => {
 			// read target manifest file
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
 			let effectivePomContent = fs.readFileSync(`test/providers/tst_manifests/maven/${testCase}/effectivePom.xml`,).toString()
-			let mockedExecFunction = function(command){
-				if(command.includes(":effective-pom")){
-					interceptAndOverwriteDataWithMock(command, effectivePomContent,"Doutput=");
+			let mockedExecFunction = function(command, args){
+				if (args.find(arg => arg.includes(":effective-pom"))){
+					interceptAndOverwriteDataWithMock(args, effectivePomContent, "Doutput=");
 				}
 			}
 			let javaMvnProvider = new Java_maven()


### PR DESCRIPTION
## Description

`execSync` was being passed a callback in order to return a custom error message, which isnt actually supported by `execSync`. Extended this to support more granular checking & reporting of errors.

This PR also changes how maven commands were invoked. Instead of building strings to pass to the shell, it invokes the passed maven binary directly and passes args via array to avoid having to do shell escaping. 

**Related issues (if any):** https://github.com/trustification/exhort-javascript-api/issues/163

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
