### PR TITLE
feat: update component analysis API to work with manifest path instead of manifest content

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,8 @@ import fs from 'node:fs'
 let stackAnalysis = await exhort.stackAnalysis('/path/to/pom.xml')
 // Get stack analysis in HTML format (string)
 let stackAnalysisHtml = await exhort.stackAnalysis('/path/to/pom.xml', true)
-
 // Get component analysis in JSON format
-let buffer = fs.readFileSync('/path/to/pom.xml')
-let componentAnalysis = await exhort.componentAnalysis('pom.xml', buffer.toString())
-
-// Get Component Analysis in JSON Format for gradle
-let caGradle = await exhort.componentAnalysis("build.gradle","",{},"path/to/build.gradle")
+let componentAnalysis = await exhort.componentAnalysis('/path/to/pom.xml')
 ```
 </li>
 </ul>
@@ -108,7 +103,7 @@ Usage: exhort-javascript-api {component|stack}
 
 Commands:
   exhort-javascript-api stack </path/to/manifest> [--html|--summary]               produce stack report for manifest path
-  exhort-javascript-api component <manifest-name> <manifest-content> [--summary]   produce component report for a manifest type and content
+  exhort-javascript-api component <path/to/manifest> [--summary]   produce component report for a manifest type and content
 
 Options:
   --help  Show help                                                    [boolean]
@@ -126,7 +121,7 @@ $ npx @RHEcosystemAppEng/exhort-javascript-api stack /path/to/pom.xml --summary
 $ npx @RHEcosystemAppEng/exhort-javascript-api stack /path/to/pom.xml --html
 
 # get component analysis
-$ npx @RHEcosystemAppEng/exhort-javascript-api component pom.xml "$(</path/to/pom.xml)"
+$ npx @RHEcosystemAppEng/exhort-javascript-api component /path/to/pom.xml
 ```
 </li>
 
@@ -148,7 +143,7 @@ $ exhort-javascript-api stack /path/to/pom.xml --summary
 $ exhort-javascript-api stack /path/to/pom.xml --html
 
 # get component analysis
-$ exhort-javascript-api component pom.xml "$(</path/to/pom.xml)"
+$ exhort-javascript-api component /path/to/pom.xml
 ```
 </li>
 </ul>
@@ -319,11 +314,7 @@ let stackAnalysis = await exhort.stackAnalysis('/path/to/pom.xml', false, option
 let stackAnalysisHtml = await exhort.stackAnalysis('/path/to/pom.xml', true, options)
 
 // Get component analysis in JSON format
-let buffer = fs.readFileSync('/path/to/pom.xml')
-let componentAnalysis = await exhort.componentAnalysis('pom.xml', buffer.toString(), options)
-
-// Get component analysis in JSON format For gradle
-let caGradle = await exhort.componentAnalysis("build.gradle","",{},"path/to/build.gradle")
+let componentAnalysis = await exhort.componentAnalysis('/path/to/pom.xml', options)
 ```
  **_Environment variables takes precedence._**
 </p>

--- a/docker-image/scripts/rhda.sh
+++ b/docker-image/scripts/rhda.sh
@@ -3,7 +3,7 @@
 manifest_file_path="$1"
 output_file_path="$2"
 
-printf "Analysing the stack. Please wait..\n\n"
+printf "Analyzing the stack. Please wait..\n\n"
 
 # Getting RHDA stack analysis report using Exhort Javascript CLI.
 report=$(exhort-javascript-api stack $manifest_file_path 2>error.log)
@@ -40,7 +40,7 @@ for provider in $providers; do
   printf "  Provider Status    :"
   printf "%+40s" $message $'\n'  | sed 's/  */ /g'
 
-  code=$(echo $provider_status | jq -r '.code')  
+  code=$(echo $provider_status | jq -r '.code')
   if [ "$code" -eq 200 ]; then
     sources=$(jq -r --arg provider "$provider" '.providers[$provider].sources | keys[]' <<< "$report")
     for source in $sources; do

--- a/integration/run_its.sh
+++ b/integration/run_its.sh
@@ -36,9 +36,9 @@ matchConstant() {
     sleep 1
     echo $TEST_MESSAGE
     if [[ "$1" != "$2" ]]; then
-        echo "- FAILED"
-       echo "expected = $1, actual= $2"
-       cleanup 1
+		echo "- FAILED"
+		echo "expected = $1, actual= $2"
+		cleanup 1
     fi
     echo "- PASSED"
     echo
@@ -91,12 +91,12 @@ testers/cli/node_modules/.bin/exhort-javascript-api  stack scenarios/maven/pom.x
 
 if [ "$?" -ne 0 ]; then
 	echo "- FAILED , return $RC from invocation"
-			cleanup $RC
+	cleanup $RC
 fi
 RESPONSE_CONTENT=$(grep -i "DOCTYPE html" ./responses/stack.html)
 if [[ -z "${RESPONSE_CONTENT}"  ]]; then
     echo "- FAILED ,return code is ok ,but received doc is not HTML"
-            cleanup 1
+	cleanup 1
 fi
 echo "- PASSED"
 echo
@@ -107,13 +107,13 @@ testers/cli/node_modules/.bin/exhort-javascript-api stack scenarios/maven/pom.xm
 
 if [ "$?" -ne 0 ]; then
 	echo "- FAILED , return $RC from invocation"
-			cleanup $RC
+	cleanup $RC
 fi
 
 RESPONSE_CONTENT=$(jq . ./responses/stack-summary.json)
 if [ "$?" -ne 0 ]; then
 	echo "- FAILED , response is not a valid json"
-			cleanup $RC
+	cleanup $RC
 fi
 echo
 echo $RESPONSE_CONTENT
@@ -128,12 +128,12 @@ testers/cli/node_modules/.bin/exhort-javascript-api stack scenarios/maven/pom.xm
 
 if [ "$?" -ne 0 ]; then
 	echo "- FAILED , return $RC from invocation"
-			cleanup $RC
+	cleanup $RC
 fi
 RESPONSE_CONTENT=$(jq . ./responses/stack.json)
 if [ "$?" -ne 0 ]; then
 	echo "- FAILED , response is not a valid json"
-			cleanup $RC
+	cleanup $RC
 fi
 StatusCodeTC=$(jq '.providers["trusted-content"].status.code' ./responses/stack.json)
 matchConstant "200" "$StatusCodeTC" "Check that Response code from Trusted Content is OK ( Http Status = 200)..."
@@ -142,16 +142,16 @@ matchConstant "200" "$StatusCodeTC" "Check that Response code from Trusted Conte
 #matchConstant "200" "$StatusCodeSnyk" "Check that Response code from Snyk Provider is OK ( Http Status = 200)..."
 
 echo "RUNNING JavaScript CLI integration test for Component Analysis report for Java Maven"
-eval "testers/cli/node_modules/.bin/exhort-javascript-api component pom.xml '$(<scenarios/maven/pom.xml)'"  > ./responses/component.json
+eval "testers/cli/node_modules/.bin/exhort-javascript-api component scenarios/maven/pom.xml"  > ./responses/component.json
 
 if [ "$?" -ne 0 ]; then
 	echo "- FAILED , return $RC from invocation"
-			cleanup $RC
+	cleanup $RC
 fi
 RESPONSE_CONTENT=$(jq . ./responses/component.json)
 if [ "$?" -ne 0 ]; then
 	echo "- FAILED , response is not a valid json, got $RC from parsing the file"
-			cleanup $RC
+	cleanup $RC
 fi
 
 StatusCodeTC=$(jq '.providers["trusted-content"].status.code' ./responses/stack.json)

--- a/integration/testers/javascript/index.js
+++ b/integration/testers/javascript/index.js
@@ -13,8 +13,8 @@ if ('stack' === args[0]) {
 	process.exit(0)
 }
 if ('component' === args[0]) {
-	// arg[1] = manifest type; arg[2] = manifest content
-	let res = await exhort.componentAnalysis(args[1], args[2])
+	// arg[1] = manifest path
+	let res = await exhort.componentAnalysis(args[1])
 	console.log(JSON.stringify(res, null, 2))
 	process.exit(0)
 }

--- a/integration/testers/typescript/index.ts
+++ b/integration/testers/typescript/index.ts
@@ -13,8 +13,8 @@ if ('stack' === args[0]) {
 	process.exit(0)
 }
 if ('component' === args[0]) {
-	// arg[1] = manifest type; arg[2] = manifest content
-	let res = await exhort.componentAnalysis(args[1], args[2])
+	// arg[1] = manifest path
+	let res = await exhort.componentAnalysis(args[1])
 	console.log(JSON.stringify(res as exhort.AnalysisReport, null, 2))
 	process.exit(0)
 }

--- a/src/analysis.js
+++ b/src/analysis.js
@@ -68,21 +68,16 @@ async function requestStack(provider, manifest, url, html = false, opts = {}) {
 /**
  * Send a component analysis request and get the report as 'application/json'.
  * @param {import('./provider').Provider} provider - the provided data for constructing the request
- * @param {string} data - the content or the path of the manifest
+ * @param {string} manifest - path for the manifest
  * @param {string} url - the backend url to send the request to
  * @param {{}} [opts={}] - optional various options to pass along the application
  * @returns {Promise<import('../generated/backend/AnalysisReport').AnalysisReport>}
  */
-async function requestComponent(provider, data, url, opts = {}, path = '') {
-	if(data.trim() !== "") {
-		opts["source-manifest"]= Buffer.from(data).toString('base64')
-		// for gradle component analysis is an exception and requires only path exclusively, and not data content.
-	}else {
-		opts["source-manifest"]= Buffer.from(fs.readFileSync(path).toString()).toString('base64')
-	}
+async function requestComponent(provider, manifest, url, opts = {}) {
+	opts["source-manifest"] = Buffer.from(fs.readFileSync(path).toString()).toString('base64')
 
-	let provided = provider.provideComponent(data, opts,path) // throws error if content providing failed
-	opts["source-manifest"]= ""
+	let provided = provider.provideComponent(path, opts) // throws error if content providing failed
+	opts["source-manifest"] = ""
 	opts[rhdaOperationTypeHeader.toUpperCase().replaceAll("-","_")] = "component-analysis"
 	if (process.env["EXHORT_DEBUG"] === "true") {
 		console.log("Starting time of sending component analysis request to exhort server= " + new Date())

--- a/src/analysis.js
+++ b/src/analysis.js
@@ -74,9 +74,9 @@ async function requestStack(provider, manifest, url, html = false, opts = {}) {
  * @returns {Promise<import('../generated/backend/AnalysisReport').AnalysisReport>}
  */
 async function requestComponent(provider, manifest, url, opts = {}) {
-	opts["source-manifest"] = Buffer.from(fs.readFileSync(path).toString()).toString('base64')
+	opts["source-manifest"] = Buffer.from(fs.readFileSync(manifest).toString()).toString('base64')
 
-	let provided = provider.provideComponent(path, opts) // throws error if content providing failed
+	let provided = provider.provideComponent(manifest, opts) // throws error if content providing failed
 	opts["source-manifest"] = ""
 	opts[rhdaOperationTypeHeader.toUpperCase().replaceAll("-","_")] = "component-analysis"
 	if (process.env["EXHORT_DEBUG"] === "true") {

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,27 +7,19 @@ import * as path from "path";
 
 // command for component analysis take manifest type and content
 const component = {
-	command: 'component <manifest-name> <manifest-content>',
-	desc: 'produce component report for a manifest type and content',
+	command: 'component </path/to/manifest>',
+	desc: 'produce component report for manifest path',
 	builder: yargs => yargs.positional(
-		'manifest-name',
+		'/path/to/manifest',
 		{
-			desc: 'manifest name and type',
+			desc: 'manifest path for analyzing',
 			type: 'string',
-			choices: ['pom.xml','package.json', 'go.mod', 'requirements.txt']
-
-		}
-	).positional(
-		'manifest-content',
-		{
-			desc: 'content of the manifest',
-			type: 'string',
+			normalize: true,
 		}
 	),
 	handler: async args => {
-		let manifestName = args['manifest-name']
-		let manifestContent = args['manifest-content']
-		let res = await exhort.componentAnalysis(manifestName, manifestContent)
+		let manifestName = args['/path/to/manifest']
+		let res = await exhort.componentAnalysis(manifestName)
 		console.log(JSON.stringify(res, null, 2))
 	}
 }
@@ -67,7 +59,7 @@ const stack = {
 	builder: yargs => yargs.positional(
 		'/path/to/manifest',
 		{
-			desc: 'manifest path for analysing',
+			desc: 'manifest path for analyzing',
 			type: 'string',
 			normalize: true,
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -56,20 +56,20 @@ function readAndPrintVersionFromPackageJson() {
  * @return {string} - The selected exhort backend
  * @private
  */
-function selectExhortBackend(opts= {}) {
+function selectExhortBackend(opts = {}) {
 	let result
 	if (process.env["EXHORT_DEBUG"] === "true") {
 		let packageJson = readAndPrintVersionFromPackageJson();
 	}
 	let exhortDevModeBundled = "false"
-	let exhortDevMode = getCustom("EXHORT_DEV_MODE",exhortDevModeBundled,opts)
+	let exhortDevMode = getCustom("EXHORT_DEV_MODE", exhortDevModeBundled, opts)
 	if(exhortDevMode !== null && exhortDevMode.toString() === "true") {
-		result = getCustom('DEV_EXHORT_BACKEND_URL',exhortDevDefaultUrl,opts);
+		result = getCustom('DEV_EXHORT_BACKEND_URL', exhortDevDefaultUrl, opts);
 	} else {
 		result = exhortDefaultUrl
 	}
 
-	logOptionsAndEnvironmentsVariables("Chosen exhort backend URL:",result)
+	logOptionsAndEnvironmentsVariables("Chosen exhort backend URL:", result)
 
 	return result;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import path from "node:path";
-import {EOL} from "os";
+import { EOL } from "os";
 import { availableProviders, match } from './provider.js'
-import {AnalysisReport} from '../generated/backend/AnalysisReport.js'
+import { AnalysisReport } from '../generated/backend/AnalysisReport.js'
 import analysis from './analysis.js'
 import fs from 'node:fs'
-import {getCustom} from "./tools.js";
+import { getCustom } from "./tools.js";
 import.meta.dirname
 import * as url from 'url';
 // const packageJson = await import ('../package.json',{ with: { type: 'json' } })
@@ -21,7 +21,6 @@ function logOptionsAndEnvironmentsVariables(alongsideText,valueToBePrinted) {
 	if (process.env["EXHORT_DEBUG"] === "true") {
 		console.log(`${alongsideText}: ${valueToBePrinted} ${EOL}`)
 	}
-
 }
 
 function readAndPrintVersionFromPackageJson() {
@@ -66,9 +65,7 @@ function selectExhortBackend(opts= {}) {
 	let exhortDevMode = getCustom("EXHORT_DEV_MODE",exhortDevModeBundled,opts)
 	if(exhortDevMode !== null && exhortDevMode.toString() === "true") {
 		result = getCustom('DEV_EXHORT_BACKEND_URL',exhortDevDefaultUrl,opts);
-	}
-	else
-	{
+	} else {
 		result = exhortDefaultUrl
 	}
 
@@ -82,8 +79,7 @@ function selectExhortBackend(opts= {}) {
  * @param opts
  * @return {string}
  */
-export function testSelectExhortBackend(opts)
-{
+export function testSelectExhortBackend(opts) {
 	return selectExhortBackend(opts)
 }
 
@@ -111,17 +107,17 @@ async function stackAnalysis(manifest, html = false, opts = {}) {
 
 /**
  * Get component analysis report for a manifest content.
- * @param {string} manifestType - the name and type of the manifest
- * @param {string} data - the content of the manifest
+ * @param {string} manifest - path to the manifest
  * @param {{}} [opts={}] - optional various options to pass along the application
  * @returns {Promise<AnalysisReport>}
  * @throws {Error} if no matching provider, failed to get create content, or backend request failed
  */
-async function componentAnalysis(manifestType, data, opts = {}, path = '') {
+async function componentAnalysis(manifest, opts = {}) {
 	theUrl = selectExhortBackend(opts)
-	opts["manifest-type"] = manifestType
-	let provider = match(manifestType, availableProviders) // throws error if no matching provider
-	return await analysis.requestComponent(provider, data, theUrl, opts,path) // throws error request sending failed
+	fs.accessSync(manifest, fs.constants.R_OK)
+	opts["manifest-type"] = path.basename(manifest)
+	let provider = match(manifest, availableProviders) // throws error if no matching provider
+	return await analysis.requestComponent(provider, manifest, theUrl, opts) // throws error request sending failed
 }
 
 async function validateToken(opts = {}) {

--- a/src/providers/golang_gomodules.js
+++ b/src/providers/golang_gomodules.js
@@ -1,12 +1,11 @@
 // import {exec} from "child_process";
 import { execSync } from "node:child_process"
 import fs from 'node:fs'
-import os from "node:os";
-import {EOL} from "os";
-import {getCustom, getCustomPath, handleSpacesInPath} from "../tools.js";
+import { EOL } from "os";
+import { getCustom, getCustomPath, handleSpacesInPath } from "../tools.js";
 import path from 'node:path'
 import Sbom from '../sbom.js'
-import {PackageURL} from 'packageurl-js'
+import { PackageURL } from 'packageurl-js'
 
 export default { isSupported, validateLockFile, provideComponent, provideStack }
 
@@ -51,30 +50,19 @@ function provideStack(manifest, opts = {}) {
 	}
 }
 
-function getComponent(data, opts) {
-	let tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exhort_'))
-	let tmpGoMod = path.join(tmpDir, 'go.mod')
-	fs.writeFileSync(tmpGoMod, data)
-	let sbom = getSBOM(tmpGoMod,opts,false);
-	fs.rmSync(tmpDir, {recursive: true, force: true})
-	return sbom
-
-}
-
 /**
  * Provide content and content type for maven-maven component analysis.
- * @param {string} data - content of go.mod for component report
+ * @param {string} manifest - path to go.mod for component report
  * @param {{}} [opts={}] - optional various options to pass along the application
  * @returns {Provided}
  */
-function provideComponent(data, opts = {}) {
+function provideComponent(manifest, opts = {}) {
 	return {
 		ecosystem,
-		content: getComponent(data,opts),
+		content: getSBOM(manifest, opts, false),
 		contentType: 'application/vnd.cyclonedx+json'
 	}
 }
-
 
 function getGoGraphCommand(goBin) {
 	return `${handleSpacesInPath(goBin)} mod graph `;

--- a/src/providers/java_gradle.js
+++ b/src/providers/java_gradle.js
@@ -2,8 +2,8 @@ import fs from 'node:fs'
 import {getCustomPath} from "../tools.js";
 import path from 'node:path'
 import Sbom from '../sbom.js'
-import {EOL} from 'os'
-import Base_java, {ecosystem_gradle} from "./base_java.js";
+import { EOL } from 'os'
+import Base_java, { ecosystem_gradle } from "./base_java.js";
 import TOML from 'fast-toml'
 
 
@@ -137,15 +137,15 @@ export default class Java_gradle extends Base_java {
 
 	/**
 	 * Provide content and content type for maven-maven component analysis.
-	 * @param {string} data - content of pom.xml for component report
+	 * @param {string} manifest - path to pom.xml for component report
 	 * @param {{}} [opts={}] - optional various options to pass along the application
 	 * @returns {Provided}
 	 */
 
-	provideComponent(data, opts = {}, path = '') {
+	provideComponent(manifest, opts = {}) {
 		return {
 			ecosystem: ecosystem_gradle,
-			content: this.#getSbomForComponentAnalysis(opts, path),
+			content: this.#getSbomForComponentAnalysis(manifest, opts),
 			contentType: 'application/vnd.cyclonedx+json'
 		}
 	}
@@ -212,7 +212,7 @@ export default class Java_gradle extends Base_java {
 	 * @returns {string} - sbom string of the direct dependencies of build.gradle
 	 * @private
 	 */
-	#getSbomForComponentAnalysis(opts = {}, manifestPath) {
+	#getSbomForComponentAnalysis(manifestPath, opts = {}) {
 		let content = this.#getDependencies(manifestPath)
 		let properties = this.#extractProperties(manifestPath, opts)
 		let configurationNames = componentAnalysisConfigs

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -152,7 +152,7 @@ export default class Java_maven extends Base_java {
 			}
 		})
 
-		const tmpEffectivePom = path.join(path.dirname(manifestPath), 'effective-pom.xml')
+		const tmpEffectivePom = path.resolve(path.join(path.dirname(manifestPath), 'effective-pom.xml'))
 		const targetPom = manifestPath
 
 		// create effective pom and save to temp file
@@ -174,7 +174,7 @@ export default class Java_maven extends Base_java {
 			let currentPurl = this.toPurl(dep.groupId, dep.artifactId, dep.version)
 			sbom.addDependency(rootComponent, currentPurl)
 		})
-		fs.rmSync(path.join(path.dirname(manifestPath), 'effective-pom.xml'))
+		fs.rmSync(tmpEffectivePom)
 
 		// return dependencies list
 		return sbom.getAsJsonString(opts)
@@ -204,7 +204,6 @@ export default class Java_maven extends Base_java {
 					pomRoot = proj
 				}
 			}
-
 		}
 		/** @type Dependency */
 		let rootDependency = {
@@ -223,8 +222,6 @@ export default class Java_maven extends Base_java {
 	 * @returns {[Dependency]} an array of dependencies
 	 * @private
 	 */
-
-
 	#getDependencies(manifest) {
 		/** @type [Dependency] */
 		let ignored = []

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -50,15 +50,15 @@ export default class Java_maven extends Base_java {
 
 	/**
 	 * Provide content and content type for maven-maven component analysis.
-	 * @param {string} data - content of pom.xml for component report
+	 * @param {string} manifest - path to the manifest file
 	 * @param {{}} [opts={}] - optional various options to pass along the application
 	 * @returns {Provided}
 	 */
 
-	provideComponent(data, opts = {}, path = '') {
+	provideComponent(manifest, opts = {}) {
 		return {
 			ecosystem: ecosystem_maven,
-			content: this.#getSbomForComponentAnalysis(data, opts, path),
+			content: this.#getSbomForComponentAnalysis(manifest, opts),
 			contentType: 'application/vnd.cyclonedx+json'
 		}
 	}
@@ -136,12 +136,11 @@ export default class Java_maven extends Base_java {
 
 	/**
 	 * Create a dependency list for a manifest content.
-	 * @param {string} data - content of pom.xml
 	 * @param {{}} [opts={}] - optional various options to pass along the application
 	 * @returns {[Dependency]} the Dot Graph content
 	 * @private
 	 */
-	#getSbomForComponentAnalysis(data, opts = {}, manifestPath) {
+	#getSbomForComponentAnalysis(manifestPath, opts = {}) {
 		// get custom maven path
 		let mvn = getCustomPath('mvn', opts)
 		// verify maven is accessible
@@ -152,21 +151,9 @@ export default class Java_maven extends Base_java {
 				throw new Error(`failed to check for maven`, {cause: error})
 			}
 		})
-		// create temp files for pom and effective pom
-		let tmpDir
-		let tmpEffectivePom
-		let targetPom
 
-		if (manifestPath.trim() === '') {
-			tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exhort_'))
-			tmpEffectivePom = path.join(tmpDir, 'effective-pom.xml')
-			targetPom = path.join(tmpDir, 'target-pom.xml')
-			// write target pom content to temp file
-			fs.writeFileSync(targetPom, data)
-		} else {
-			tmpEffectivePom = path.join(path.dirname(manifestPath), 'effective-pom.xml')
-			targetPom = manifestPath
-		}
+		const tmpEffectivePom = path.join(path.dirname(manifestPath), 'effective-pom.xml')
+		const targetPom = manifestPath
 
 		// create effective pom and save to temp file
 		this._invokeCommand(mvn, ['-q', 'help:effective-pom', `-Doutput=${tmpEffectivePom}`, '-f', targetPom], error => {
@@ -187,12 +174,7 @@ export default class Java_maven extends Base_java {
 			let currentPurl = this.toPurl(dep.groupId, dep.artifactId, dep.version)
 			sbom.addDependency(rootComponent, currentPurl)
 		})
-		if (manifestPath.trim() === '') {
-			// delete temp files and directory
-			fs.rmSync(tmpDir, {recursive: true, force: true})
-		} else {
-			fs.rmSync(path.join(path.dirname(manifestPath), 'effective-pom.xml'))
-		}
+		fs.rmSync(path.join(path.dirname(manifestPath), 'effective-pom.xml'))
 
 		// return dependencies list
 		return sbom.getAsJsonString(opts)

--- a/src/providers/javascript_npm.js
+++ b/src/providers/javascript_npm.js
@@ -4,7 +4,7 @@ import os from "node:os";
 import { getCustomPath, handleSpacesInPath } from "../tools.js";
 import path from 'node:path'
 import Sbom from '../sbom.js'
-import {PackageURL} from 'packageurl-js'
+import { PackageURL } from 'packageurl-js'
 
 export var npmInteractions = {
 	listing: function runNpmListing(npmListing) {
@@ -91,34 +91,16 @@ function provideStack(manifest, opts = {}) {
 	}
 }
 
-function getComponent(data, opts,manifestPath) {
-	let sbom
-	if(manifestPath.trim() === '') {
-		let tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exhort_'))
-		let tmpPackageJson = path.join(tmpDir, 'package.json')
-		fs.writeFileSync(tmpPackageJson, data)
-		sbom = getSBOM(tmpPackageJson,opts,false);
-		fs.rmSync(tmpDir, {recursive: true, force: true})
-	}
-	else {
-		sbom = getSBOM(manifestPath,opts,false);
-	}
-
-
-	return sbom
-
-}
-
 /**
  * Provide content and content type for maven-maven component analysis.
- * @param {string} data - content of pom.xml for component report
+ * @param {string} manifest - path to pom.xml for component report
  * @param {{}} [opts={}] - optional various options to pass along the application
  * @returns {Provided}
  */
-function provideComponent(data, opts = {}, path = '') {
+function provideComponent(manifest, opts = {}) {
 	return {
 		ecosystem,
-		content: getComponent(data,opts,path),
+		content: getSBOM(manifest, opts,false),
 		contentType: 'application/vnd.cyclonedx+json'
 	}
 }

--- a/src/providers/python_pip.js
+++ b/src/providers/python_pip.js
@@ -81,27 +81,21 @@ function addAllDependencies(source, dep, sbom) {
 	if (directDeps !== undefined && directDeps.length > 0) {
 		directDeps.forEach( (dependency) =>{ addAllDependencies(toPurl(dep["name"],dep["version"]),dependency,sbom)})
 	}
-
-
 }
-
-
 
 /**
  *
  * @param nameVersion
  * @return {string}
  */
-function splitToNameVersion(nameVersion)
-{
+function splitToNameVersion(nameVersion) {
 	let result = []
 	if(nameVersion.includes("==")) {
 		result = nameVersion.split("==")
-	}
-	else {
+	} else {
 		const regex = /[^\w\s-_]/g;
 		let endIndex = nameVersion.search(regex);
-		result.push(nameVersion.substring(0,endIndex).trim())
+		result.push(nameVersion.substring(0, endIndex).trim())
 		result.push(dummyVersionNotation)
 	}
 
@@ -130,7 +124,7 @@ function getIgnoredDependencies(requirementTxtContent) {
  * @param {{Object}} opts - various options and settings for the application
  * @private
  */
-function handleIgnoredDependencies(requirementTxtContent, sbom,opts ={}) {
+function handleIgnoredDependencies(requirementTxtContent, sbom, opts ={}) {
 	let ignoredDeps = getIgnoredDependencies(requirementTxtContent)
 	let ignoredDepsVersion = ignoredDeps
 		.filter(dep => !dep.toString().includes(dummyVersionNotation) )
@@ -142,9 +136,7 @@ function handleIgnoredDependencies(requirementTxtContent, sbom,opts ={}) {
 	let matchManifestVersions = getCustom("MATCH_MANIFEST_VERSIONS","true",opts);
 	if(matchManifestVersions === "true") {
 		sbom.filterIgnoredDepsIncludingVersion(ignoredDepsVersion)
-	}
-	else
-	{
+	} else {
 		// in case of version mismatch, need to parse the name of package from the purl, and remove the package name from sbom according to name only
 		// without version
 		sbom.filterIgnoredDeps(ignoredDepsVersion.map((dep) => dep.split("@")[0].split("pkg:pypi/")[1]))
@@ -173,8 +165,6 @@ function getPythonPipBinaries(binaries,opts) {
 	}
 	binaries.pip = pip
 	binaries.python = python
-
-
 }
 
 /**
@@ -214,7 +204,6 @@ function createSbomStackAnalysis(manifest, opts = {}) {
 	let binaries = {}
 	let createVirtualPythonEnv = handlePythonEnvironment(binaries, opts);
 
-
 	let pythonController = new Python_controller(createVirtualPythonEnv === "false",binaries.pip,binaries.python,manifest,opts)
 	let dependencies = pythonController.getDependencies(true);
 	let sbom = new Sbom();
@@ -227,8 +216,6 @@ function createSbomStackAnalysis(manifest, opts = {}) {
 	// In python there is no root component, then we must remove the dummy root we added, so the sbom json will be accepted by exhort backend
 	// sbom.removeRootComponent()
 	return sbom.getAsJsonString(opts)
-
-
 }
 
 /**
@@ -248,12 +235,12 @@ function getSbomForComponentAnalysis(manifest, opts = {}) {
 	dependencies.forEach(dep => {
 		sbom.addDependency(sbom.getRoot(), toPurl(dep.name, dep.version))
 	})
-	handleIgnoredDependencies(manifest, sbom, opts)
+	let requirementTxtContent = fs.readFileSync(manifest).toString();
+	handleIgnoredDependencies(requirementTxtContent, sbom, opts)
 	// In python there is no root component, then we must remove the dummy root we added, so the sbom json will be accepted by exhort backend
 	// sbom.removeRootComponent()
 	return sbom.getAsJsonString(opts)
 }
-
 
 /**
  * Returns a PackageUrl For pip dependencies
@@ -261,9 +248,6 @@ function getSbomForComponentAnalysis(manifest, opts = {}) {
  * @param version
  * @return {PackageURL}
  */
-function toPurl(name,version)
-{
+function toPurl(name,version) {
 	return new PackageURL('pypi',undefined,name,version,undefined,undefined);
 }
-
-

--- a/src/tools.js
+++ b/src/tools.js
@@ -38,9 +38,8 @@ export function logValueFromObjects(key,opts, defValue) {
  * 		default supplied
  */
 export function getCustom(key, def = null, opts = {}) {
-	if (process.env["EXHORT_DEBUG"] === "true" && !key.match(RegexNotToBeLogged))
-	{
-		logValueFromObjects(key,opts,def)
+	if (process.env["EXHORT_DEBUG"] === "true" && !key.match(RegexNotToBeLogged)) {
+		logValueFromObjects(key, opts, def)
 	}
 	return key in process.env ? process.env[key] : key in opts && typeof opts[key] === 'string' ? opts[key] : def
 }

--- a/src/tools.js
+++ b/src/tools.js
@@ -59,6 +59,10 @@ export function getCustomPath(name, opts = {}) {
 	return getCustom(`EXHORT_${name.toUpperCase()}_PATH`, name, opts)
 }
 
+export function getWrapperPreference(name, opts = {}) {
+	return getCustom(`EXHORT_PREFER_${name.toUpperCase()}W`, true, opts)
+}
+
 export function environmentVariableIsPopulated(envVariableName) {
 	return envVariableName in process.env && process.env[envVariableName].trim() !== "";
 }

--- a/test/providers/golang_gomodules.test.js
+++ b/test/providers/golang_gomodules.test.js
@@ -44,10 +44,8 @@ suite('testing the golang-go-modules data provider', () => {
 			// load the expected list for the scenario
 			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/golang/${testCase}/expected_sbom_component_analysis.json`,).toString().trimEnd()
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
-			// read target manifest file
-			let manifestContent = fs.readFileSync(`test/providers/tst_manifests/golang/${testCase}/go.mod`).toString()
 			// invoke sut stack analysis for scenario manifest
-			let providedDataForComponent = await golangGoModules.provideComponent(manifestContent)
+			let providedDataForComponent = await golangGoModules.provideComponent(`test/providers/tst_manifests/golang/${testCase}/go.mod`)
 			// verify returned data matches expectation
 			expect(providedDataForComponent.ecosystem).equal('golang')
 			expect(providedDataForComponent.contentType).equal('application/vnd.cyclonedx+json')

--- a/test/providers/java_gradle_groovy.test.js
+++ b/test/providers/java_gradle_groovy.test.js
@@ -80,7 +80,7 @@ suite('testing the java-gradle-groovy data provider', () => {
 			let javaGradleProvider = new Java_gradle_groovy()
 			Object.getPrototypeOf(Object.getPrototypeOf(javaGradleProvider))._invokeCommand = mockedExecFunction
 			// invoke sut component analysis for scenario manifest
-			let provdidedForComponent = javaGradleProvider.provideComponent("",{},`test/providers/tst_manifests/gradle/${testCase}/build.gradle`)
+			let provdidedForComponent = javaGradleProvider.provideComponent(`test/providers/tst_manifests/gradle/${testCase}/build.gradle`, {})
 			// verify returned data matches expectation
 			let beautifiedOutput = JSON.stringify(JSON.parse(provdidedForComponent.content),null, 4);
 			expect(beautifiedOutput).to.deep.equal(expectedSbom)

--- a/test/providers/java_gradle_kotlin.test.js
+++ b/test/providers/java_gradle_kotlin.test.js
@@ -80,7 +80,7 @@ suite('testing the java-gradle-kotlin data provider', () => {
 			let javaGradleProvider = new Java_gradle_kotlin()
 			Object.getPrototypeOf(Object.getPrototypeOf(javaGradleProvider))._invokeCommand = mockedExecFunction
 			// invoke sut component analysis for scenario manifest
-			let provdidedForComponent = javaGradleProvider.provideComponent("",{},`test/providers/tst_manifests/gradle/${testCase}/build.gradle.kts`)
+			let provdidedForComponent = javaGradleProvider.provideComponent(`test/providers/tst_manifests/gradle/${testCase}/build.gradle.kts`, {})
 			// verify returned data matches expectation
 			let beautifiedOutput = JSON.stringify(JSON.parse(provdidedForComponent.content),null, 4);
 			expect(beautifiedOutput).to.deep.equal(expectedSbom)

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -90,7 +90,6 @@ suite('testing the java-maven data provider', () => {
 			// read target manifest file
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
 			let effectivePomContent = fs.readFileSync(`test/providers/tst_manifests/maven/${testCase}/effective-pom.xml`,).toString()
-			let manifestContent = fs.readFileSync(`test/providers/tst_manifests/maven/${testCase}/pom.xml`).toString()
 			let mockedExecFunction = function(bin, args){
 				if (args.find(arg => arg.includes(":effective-pom"))){
 					interceptAndOverwriteDataWithMock(args, effectivePomContent, "Doutput=");
@@ -99,7 +98,7 @@ suite('testing the java-maven data provider', () => {
 			let javaMvnProvider = new Java_maven()
 			Object.getPrototypeOf(Object.getPrototypeOf(javaMvnProvider))._invokeCommand = mockedExecFunction
 			// invoke sut component analysis for scenario manifest
-			let providedDataForStack = javaMvnProvider.provideComponent(manifestContent)
+			let providedDataForStack = javaMvnProvider.provideComponent(`test/providers/tst_manifests/maven/${testCase}/pom.xml`)
 			// verify returned data matches expectation
 			expect(providedDataForStack).to.deep.equal({
 				ecosystem: 'maven',
@@ -134,7 +133,7 @@ suite('testing the java-maven data provider with modules', () => {
 			let javaMvnProvider = new Java_maven()
 			Object.getPrototypeOf(Object.getPrototypeOf(javaMvnProvider))._invokeCommand = mockedExecFunction
 			// invoke sut component analysis for scenario manifest
-			let provideDataForComponent = javaMvnProvider.provideComponent("",{},`test/providers/tst_manifests/maven/${testCase}/pom.xml`)
+			let provideDataForComponent = javaMvnProvider.provideComponent(`test/providers/tst_manifests/maven/${testCase}/pom.xml`, {})
 			// verify returned data matches expectation
 			expect(provideDataForComponent).to.deep.equal({
 				ecosystem: 'maven',

--- a/test/providers/javascript_npm.test.js
+++ b/test/providers/javascript_npm.test.js
@@ -79,8 +79,6 @@ suite('testing the javascript-npm data provider', async() => {
 			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/npm/${testCase}/component_expected_sbom.json`,).toString().trim()
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
 			let npmListing = fs.readFileSync(`test/providers/tst_manifests/npm/${testCase}/npm_listing_component.json`,).toString()
-			// read target manifest file
-			let manifestContent = fs.readFileSync(`test/providers/tst_manifests/npm/${testCase}/package.json`).toString()
 			// sinon.stub(javascriptNpmProviderSource,'runNpmListing').callsFake(() => npmListing)
 			let mpmMockedInteractions = {
 				listing: () => npmListing,
@@ -89,7 +87,7 @@ suite('testing the javascript-npm data provider', async() => {
 			}
 			javascriptNpmProviderRewire.__set__('npmInteractions', mpmMockedInteractions)
 			// invoke sut stack analysis for scenario manifest
-			let providedDataForStack = await javascriptNpmProviderRewire.__get__("provideComponent")(manifestContent)
+			let providedDataForStack = await javascriptNpmProviderRewire.__get__("provideComponent")(`test/providers/tst_manifests/npm/${testCase}/package.json`)
 			// verify returned data matches expectation
 			expect(providedDataForStack).to.deep.equal({
 				ecosystem: 'npm',

--- a/test/providers/python_pip.test.js
+++ b/test/providers/python_pip.test.js
@@ -5,19 +5,15 @@ import sinon from "sinon";
 import pythonPip from "../../src/providers/python_pip.js"
 import {getCustomPath } from "../../src/tools.js"
 
-
-
 let clock
 
 async function sharedComponentAnalysisTestFlow(testCase,usePipDepTreeUtility) {
 	// load the expected list for tsharedComponentAnalysisTestFlowhe scenario
 	let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/pip/${testCase}/expected_component_sbom.json`,).toString().trim()
 	expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
-	// read target manifest file
-	let manifestContent = fs.readFileSync(`test/providers/tst_manifests/pip/${testCase}/requirements.txt`).toString()
 	// invoke sut stack analysis for scenario manifest
 	let opts = { "EXHORT_PIP_USE_DEP_TREE" : usePipDepTreeUtility }
-	let providedDatForComponent = await pythonPip.provideComponent(manifestContent,opts)
+	let providedDatForComponent = await pythonPip.provideComponent(`test/providers/tst_manifests/pip/${testCase}/requirements.txt`, opts)
 	// verify returned data matches expectation
 	expect(providedDatForComponent).to.deep.equal({
 		ecosystem: 'pip',


### PR DESCRIPTION
## Description

Updates the API for the `componentAnalysis` entrypoint to match changes made to the component analysis entrypoint in the Java API (see linked issue below). Component analysis now always operates off the manifest path (as the gradle analysis provider already did) instead of manifest content, same as stack analysis.

Note: This is a breaking change to the API.

**Related issues (if any):** https://github.com/trustification/exhort-javascript-api/issues/166

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
