### PR TITLE
fix: bug in handling of comments with leading whitespace in requirements.txt

### DIFF
--- a/src/providers/python_controller.js
+++ b/src/providers/python_controller.js
@@ -204,7 +204,7 @@ export default class Python_controller {
 		// pipShowOutput = "alternative pip show output goes here for debugging"
 
 		let matchManifestVersions = getCustom("MATCH_MANIFEST_VERSIONS","true",this.options);
-		let linesOfRequirements = fs.readFileSync(this.pathToRequirements).toString().split(EOL).filter( (line) => !line.startsWith("#")).map(line => line.trim())
+		let linesOfRequirements = fs.readFileSync(this.pathToRequirements).toString().split(EOL).filter( (line) => !line.trim().startsWith("#")).map(line => line.trim())
 		let CachedEnvironmentDeps = {}
 		if(usePipDepTree !== "true") {
 			allPipShowDeps.forEach((record) => {

--- a/test/it/test_manifests/pip/requirements.txt
+++ b/test/it/test_manifests/pip/requirements.txt
@@ -1,3 +1,6 @@
 anyio==3.6.2
+	# fakepackage==11.69
 click==8.0.4
+	# sample comment that should definitely not be resolved
 Flask==2.0.3
+# another sample comment


### PR DESCRIPTION
## Description

We read requirements.txt in (at least) 2 places to parse the lines for dependencies to resolve. We are meant to ignore comments but in one section we were not removing leading whitespace before checking for the presence of the comment token `#`

**Related issues (if any):** https://github.com/trustification/exhort-javascript-api/issues/167

- fixes: https://github.com/trustification/exhort-javascript-api/issues/167

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
