### PR TITLE
feat: support mvnw if requested and exists

### DIFF
--- a/integration/run_its.sh
+++ b/integration/run_its.sh
@@ -81,7 +81,7 @@ mkdir -p ./responses
 #### JAVA MAVEN
 echo "RUNNING JavaScript CLI integration test for Stack Analysis report in Html for Java Maven"
 
-testers/cli/node_modules/.bin/exhort-javascript-api  stack scenarios/maven/pom.xml --html &> ./responses/stack.html
+testers/cli/node_modules/.bin/exhort-javascript-api  stack scenarios/maven/pom.xml --html > ./responses/stack.html
 RC="$?"
 if [ "$RC" -ne 0 ]; then
 	echo "- FAILED, return $RC from invocation"

--- a/integration/run_its.sh
+++ b/integration/run_its.sh
@@ -20,21 +20,10 @@ cleanup() {
 	exit "$1"
 }
 
-# utility function takes file name and a command
-# used for matching the file content and the command output
-match() {
-	if [[ $(< "$1") != "$(eval "$2")" ]]; then
-        echo "- FAILED"
-        cleanup 1
-    fi
-    echo "- PASSED"
-    echo
-}
-
 matchConstant() {
     TEST_MESSAGE="$3"
     sleep 1
-    echo $TEST_MESSAGE
+    echo "$TEST_MESSAGE"
     if [[ "$1" != "$2" ]]; then
 		echo "- FAILED"
 		echo "expected = $1, actual= $2"
@@ -49,25 +38,29 @@ matchConstant() {
 ##########################################
 echo "VERIFYING Node and NPM availability"
 if ! node --version > /dev/null 2>&1; then
+	RC="$?"
 	echo "- FAILED Node not found"
-	cleanup $?
+	cleanup $RC
 fi
 
 if ! npm --version > /dev/null 2>&1; then
+	RC="$?"
 	echo "- FAILED NPM not found"
-	cleanup $?
+	cleanup $RC
 fi
 echo "- SUCCESSFUL"
 
 echo "VERIFYING Java and Maven availability"
 if ! java --version > /dev/null 2>&1; then
+	RC="$?"
 	echo "- FAILED Java not found"
-	cleanup $?
+	cleanup $RC
 fi
 
 if ! mvn --version > /dev/null 2>&1; then
+	RC="$?"
 	echo "- FAILED Maven not found"
-	cleanup $?
+	cleanup $RC
 fi
 echo "- SUCCESSFUL"
 
@@ -79,8 +72,9 @@ echo "PREPARING JavaScript CLI tests environment"
 rm -rf testers/cli/node_modules
 rm -f testers/cli/package-lock.json
 if !  npm --prefix testers/cli install  --silent ; then
+	RC="$?"
 	echo "- FAILED Installing exhort-javascript-api environment for testing"
-	cleanup $?
+	cleanup $RC
 fi
 echo "- SUCCESSFUL"
 mkdir -p ./responses
@@ -88,53 +82,51 @@ mkdir -p ./responses
 echo "RUNNING JavaScript CLI integration test for Stack Analysis report in Html for Java Maven"
 
 testers/cli/node_modules/.bin/exhort-javascript-api  stack scenarios/maven/pom.xml --html &> ./responses/stack.html
-
-if [ "$?" -ne 0 ]; then
-	echo "- FAILED , return $RC from invocation"
+RC="$?"
+if [ "$RC" -ne 0 ]; then
+	echo "- FAILED, return $RC from invocation"
 	cleanup $RC
 fi
 RESPONSE_CONTENT=$(grep -i "DOCTYPE html" ./responses/stack.html)
 if [[ -z "${RESPONSE_CONTENT}"  ]]; then
-    echo "- FAILED ,return code is ok ,but received doc is not HTML"
+    echo "- FAILED, response is not valid html: $RESPONSE_CONTENT"
 	cleanup 1
 fi
 echo "- PASSED"
 echo
 
 echo 'RUNNING JavaScript CLI integration test for Stack Analysis report summary of snyk provider for Java Maven'
-
 testers/cli/node_modules/.bin/exhort-javascript-api stack scenarios/maven/pom.xml --summary > ./responses/stack-summary.json
-
-if [ "$?" -ne 0 ]; then
-	echo "- FAILED , return $RC from invocation"
+RC="$?"
+if [ "$RC" -ne 0 ]; then
+	echo "- FAILED, return $RC from invocation"
 	cleanup $RC
 fi
 
-RESPONSE_CONTENT=$(jq . ./responses/stack-summary.json)
-if [ "$?" -ne 0 ]; then
-	echo "- FAILED , response is not a valid json"
+if ! RESPONSE_CONTENT=$(jq . ./responses/stack-summary.json); then
+	RC="$?"
+	echo "- FAILED, response is not a valid json: $RESPONSE_CONTENT"
 	cleanup $RC
 fi
 echo
-echo $RESPONSE_CONTENT
+echo "$RESPONSE_CONTENT"
 echo "- PASSED"
 echo
 
-
-
-
 echo "RUNNING JavaScript CLI integration test for Stack Analysis report in Json for Java Maven"
 testers/cli/node_modules/.bin/exhort-javascript-api stack scenarios/maven/pom.xml  > ./responses/stack.json
+RC="$?"
+if [ "$RC" -ne 0 ]; then
+	echo "- FAILED, return $RC from invocation"
+	cleanup $RC
+fi
 
-if [ "$?" -ne 0 ]; then
-	echo "- FAILED , return $RC from invocation"
+if ! RESPONSE_CONTENT=$(jq . ./responses/stack.json); then
+	RC="$?"
+	echo "- FAILED, response is not a valid json: $RESPONSE_CONTENT"
 	cleanup $RC
 fi
-RESPONSE_CONTENT=$(jq . ./responses/stack.json)
-if [ "$?" -ne 0 ]; then
-	echo "- FAILED , response is not a valid json"
-	cleanup $RC
-fi
+
 StatusCodeTC=$(jq '.providers["trusted-content"].status.code' ./responses/stack.json)
 matchConstant "200" "$StatusCodeTC" "Check that Response code from Trusted Content is OK ( Http Status = 200)..."
 
@@ -143,14 +135,15 @@ matchConstant "200" "$StatusCodeTC" "Check that Response code from Trusted Conte
 
 echo "RUNNING JavaScript CLI integration test for Component Analysis report for Java Maven"
 eval "testers/cli/node_modules/.bin/exhort-javascript-api component scenarios/maven/pom.xml"  > ./responses/component.json
-
-if [ "$?" -ne 0 ]; then
-	echo "- FAILED , return $RC from invocation"
+RC="$?"
+if [ "$RC" -ne 0 ]; then
+	echo "- FAILED, return $RC from invocation"
 	cleanup $RC
 fi
-RESPONSE_CONTENT=$(jq . ./responses/component.json)
-if [ "$?" -ne 0 ]; then
-	echo "- FAILED , response is not a valid json, got $RC from parsing the file"
+
+if ! RESPONSE_CONTENT=$(jq . ./responses/component.json); then
+	RC="$?"
+	echo "- FAILED, response is not a valid json, got $RC from parsing the file"
 	cleanup $RC
 fi
 
@@ -161,11 +154,11 @@ matchConstant "200" "$StatusCodeTC" "Check that Response code from Trusted Conte
 
 echo "RUNNING JavaScript CLI integration test for Validate Token Function With wrong token, expecting getting 401 http status code "
 answerAboutToken=$(testers/cli/node_modules/.bin/exhort-javascript-api validate-token snyk --value=veryBadTokenValue)
-matchConstant "401" "$answerAboutToken" "Checking That dummy Token is Invalid , Expecting Response Status of Authentication Failure( Http Status = 401)..."
+matchConstant "401" "$answerAboutToken" "Checking That dummy Token is Invalid, Expecting Response Status of Authentication Failure( Http Status = 401)..."
 
 echo "RUNNING JavaScript CLI  integration test for Validate Token Function With no token at all, Expecting getting 400 http status code"
 answerAboutToken=$(testers/cli/node_modules/.bin/exhort-javascript-api validate-token snyk )
-matchConstant "400" "$answerAboutToken" "Checking That Token is missing , Expecting Response Status of Bad Request( Http Status = 400)..."
+matchConstant "400" "$answerAboutToken" "Checking That Token is missing, Expecting Response Status of Bad Request( Http Status = 400)..."
 echo "==>SUCCESS!!"
 
 cleanup 0

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -237,10 +237,10 @@ export default class Java_maven extends Base_java {
 	#traverseForMvnw(startingManifest, repoRoot = undefined) {
 		repoRoot = repoRoot || getGitRootDir(path.dirname(startingManifest)) || path.parse(path.resolve(startingManifest)).root
 		try {
-			fs.accessSync(path.join(path.dirname(startingManifest), 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')), fs.constants.X_OK)
+			fs.accessSync(path.join(path.resolve(path.dirname(startingManifest)), 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')), fs.constants.X_OK)
 		} catch(error) {
 			if (error.code === 'ENOENT') {
-				if (path.dirname(startingManifest) === repoRoot) {
+				if (path.resolve(path.dirname(startingManifest)) === repoRoot) {
 					return undefined
 				}
 				return this.#traverseForMvnw(path.dirname(startingManifest), repoRoot)

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -235,7 +235,7 @@ export default class Java_maven extends Base_java {
 	 * @returns
 	 */
 	#traverseForMvnw(startingManifest, repoRoot = undefined) {
-		repoRoot = repoRoot || getGitRootDir(path.dirname(startingManifest)) || path.parse(path.resolve(startingManifest)).root
+		repoRoot = repoRoot || getGitRootDir(path.resolve(path.dirname(startingManifest))) || path.parse(path.resolve(startingManifest)).root
 		try {
 			fs.accessSync(path.join(path.resolve(path.dirname(startingManifest)), 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')), fs.constants.X_OK)
 		} catch(error) {
@@ -243,11 +243,11 @@ export default class Java_maven extends Base_java {
 				if (path.resolve(path.dirname(startingManifest)) === repoRoot) {
 					return undefined
 				}
-				return this.#traverseForMvnw(path.dirname(startingManifest), repoRoot)
+				return this.#traverseForMvnw(path.resolve(path.dirname(startingManifest)), repoRoot)
 			}
 			throw new Error(`failure searching for mvnw`, {cause: error})
 		}
-		return path.join(path.dirname(startingManifest), 'mvnw' + (process.platform === 'win32' ? '.cmd' : ''))
+		return path.join(path.resolve(path.dirname(startingManifest)), 'mvnw' + (process.platform === 'win32' ? '.cmd' : ''))
 	}
 
 	/**

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -200,7 +200,7 @@ export default class Java_maven extends Base_java {
 		// get custom maven path
 		let mvn = getCustomPath('mvn', opts)
 
-		// check if mvnw is preferred anda available
+		// check if mvnw is preferred and available
 		let useMvnw = getWrapperPreference('mvn', opts)
 		if (useMvnw) {
 			const mvnw = this.#traverseForMvnw(manifestPath)
@@ -236,8 +236,12 @@ export default class Java_maven extends Base_java {
 	 */
 	#traverseForMvnw(startingManifest, repoRoot = undefined) {
 		repoRoot = repoRoot || getGitRootDir(path.resolve(path.dirname(startingManifest))) || path.parse(path.resolve(startingManifest)).root
+
+		const wrapperName = 'mvnw' + (process.platform === 'win32' ? '.cmd' : '');
+		const wrapperPath = path.join(path.resolve(path.dirname(startingManifest)), wrapperName);
+
 		try {
-			fs.accessSync(path.join(path.resolve(path.dirname(startingManifest)), 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')), fs.constants.X_OK)
+			fs.accessSync(wrapperPath, fs.constants.X_OK)
 		} catch(error) {
 			if (error.code === 'ENOENT') {
 				if (path.resolve(path.dirname(startingManifest)) === repoRoot) {
@@ -247,7 +251,7 @@ export default class Java_maven extends Base_java {
 			}
 			throw new Error(`failure searching for mvnw`, {cause: error})
 		}
-		return path.join(path.resolve(path.dirname(startingManifest)), 'mvnw' + (process.platform === 'win32' ? '.cmd' : ''))
+		return wrapperPath
 	}
 
 	/**

--- a/src/tools.js
+++ b/src/tools.js
@@ -58,8 +58,15 @@ export function getCustomPath(name, opts = {}) {
 	return getCustom(`EXHORT_${name.toUpperCase()}_PATH`, name, opts)
 }
 
+/**
+ * Utility function for determining whether wrappers for build tools such as gradlew/mvnw should be
+ * preferred over invoking the binary directly.
+ * @param {string} name - binary for which to search for its wrapper
+ * @param {{}} opts - the options object to look for the key in if not found in environment
+ * @returns {boolean} whether to prefer the wrapper if exists or not
+ */
 export function getWrapperPreference(name, opts = {}) {
-	return getCustom(`EXHORT_PREFER_${name.toUpperCase()}W`, true, opts)
+	return getCustom(`EXHORT_PREFER_${name.toUpperCase()}W`, 'true', opts) === 'true'
 }
 
 export function environmentVariableIsPopulated(envVariableName) {
@@ -99,6 +106,18 @@ function hasSpaces(path) {
 	return path.trim().includes(" ")
 }
 
+
+/**
+ *
+ * @param {string} cwd - directory for which to find the root of the git repository.
+ */
+export function getGitRootDir(cwd) {
+	const root = invokeCommand('git', ['rev-parse', '--show-toplevel'], () => {}, {cwd: cwd})
+	if (!root) {
+		return undefined
+	}
+	return root.toString().trim()
+}
 
 /** this method invokes command string in a process in a synchronous way.
  * @param {string} bin - the command to be invoked


### PR DESCRIPTION
## Description

Adds support for using [mvnw](https://maven.apache.org/wrapper/) instead of maven from PATH/EXHORT_MVN_PATH. If set, mvnw is searched for starting in the directory the passed manifest is in, traversing upwards until either the git repo root is hit, or the root of the drive. 

The `EXHORT_PREFER_MVNW` env var controls this preference.

**Related issues (if any):** https://github.com/trustification/exhort-javascript-api/issues/169

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
