### PR TITLE
chore: update references from RHEcosystemAppEng to trustification

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: GitHub Discussions
-    url: https://github.com/RHEcosystemAppEng/exhort-java-api/discussions/
+    url: https://github.com/trustification/exhort-java-api/discussions/
     about: You can also use Discussions for questions and ideas.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: staging
-    if: github.repository_owner == 'RHEcosystemAppEng' && github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/' )
+    if: github.repository_owner == 'trustification' && github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/' )
     name: Release the project
     steps:
       - name: Checkout sources

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -29,7 +29,7 @@ jobs:
   stage:
     runs-on: ubuntu-latest
 #    Branches that starts with `release/` shouldn't trigger this workflow, as these are triggering the release workflow.
-    if: github.repository_owner == 'RHEcosystemAppEng' && github.event.pull_request.merged == true &&  !startsWith(github.head_ref, 'release/')
+    if: github.repository_owner == 'trustification' && github.event.pull_request.merged == true && !startsWith(github.head_ref, 'release/')
     environment: staging
     name: Stage the project
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ scripts in [integration/testers](integration/testers).<br/>
 
 We have 3 _testers_:
 * [integration/testers/cli](integration/testers/cli) is a _package.json_ used for installing the _ESM module_.
-  Invoking the CLI Script is done against the _@RHEcosystemAppEng/exhort-javascript-api/dist/src/cli.js_ in the tester's
+  Invoking the CLI Script is done against the _@trustification/exhort-javascript-api/dist/src/cli.js_ in the tester's
   _node_modules_.
 * [integration/testers/javascript](integration/testers/javascript) is a _javascript_ script invoking the _ESM module_.
 * [integration/testers/typescript](integration/testers/typescript) is a _typescript_ script invoking the _ESM module_.
@@ -125,7 +125,7 @@ contribution. See the [DCO](DCO) file for details.
 
 <!-- Real links -->
 [0]: https://www.conventionalcommits.org/en/v1.0.0/
-[1]: https://github.com/RHEcosystemAppEng/exhort/blob/0.1.x/src/main/resources/META-INF/openapi.yaml
+[1]: https://github.com/trustification/exhort/blob/0.1.x/src/main/resources/META-INF/openapi.yaml
 
 <!-- Badge links -->
 [10]: https://badgen.net/badge/NodeJS%20Version/18/68a063

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Exhort JavaScript API<br/>![latest-no-snapshot][0] ![latest-snapshot][1]
 
-* Looking for our Java API? Try [Exhort Java API](https://github.com/RHEcosystemAppEng/exhort-java-api).
-* Looking for our Backend implementation? Try [Exhort](https://github.com/RHEcosystemAppEng/exhort).
+* Looking for our Java API? Try [Exhort Java API](https://github.com/trustification/exhort-java-api).
+* Looking for our Backend implementation? Try [Exhort](https://github.com/trustification/exhort).
 
 The _Exhort JavaScript API_ module is deployed to _GitHub Package Registry_.
 
@@ -30,11 +30,11 @@ See [GH Docs](https://docs.github.com/en/packages/working-with-a-github-packages
 
 <h3>Usage</h3>
 <p>
-Configuring <em>NPM</em> to look in <em>GHPR</em> for the <em>RHEcosystemAppEng</em> namespace is done by adding
-<code>@RHEcosystemAppEng:registry=https://npm.pkg.github.com</code> to <em>.npmrc</em> in the project root or user home.
+Configuring <em>NPM</em> to look in <em>GHPR</em> for the <em>trustification</em> namespace is done by adding
+<code>@trustification:registry=https://npm.pkg.github.com</code> to <em>.npmrc</em> in the project root or user home.
 
 ```shell
-echo "@RHEcosystemAppEng:registry=https://npm.pkg.github.com" >> .npmrc
+echo "@trustification:registry=https://npm.pkg.github.com" >> .npmrc
 ```
 </p>
 
@@ -43,11 +43,11 @@ echo "@RHEcosystemAppEng:registry=https://npm.pkg.github.com" >> .npmrc
 Use as ESM Module from an ESM module
 
 ```shell
-npm install @RHEcosystemAppEng/exhort-javascript-api
+npm install @trustification/exhort-javascript-api
 ```
 
 ```javascript
-import exhort from '@RHEcosystemAppEng/exhort-javascript-api'
+import exhort from '@trustification/exhort-javascript-api'
 import fs from 'node:fs'
 
 // Get stack analysis in JSON format
@@ -64,14 +64,14 @@ let componentAnalysis = await exhort.componentAnalysis('/path/to/pom.xml')
 Use as ESM Module from Common-JS module
 
 ```shell
-npm install @RHEcosystemAppEng/exhort-javascript-api
+npm install @trustification/exhort-javascript-api
 ```
 
 ```javascript
 async function loadExhort()
 {
 // dynamic import is the only way to import ESM module into commonJS module
-  const { default: exhort } = await import('@RHEcosystemAppEng/exhort-javascript-api');
+  const { default: exhort } = await import('@trustification/exhort-javascript-api');
   return exhort
 }
 const runExhort = (manifestPath) => {
@@ -97,7 +97,7 @@ Use as CLI Script
 <summary>Click for help menu</summary>
 
 ```shell
-$ npx @RHEcosystemAppEng/exhort-javascript-api help
+$ npx @trustification/exhort-javascript-api help
 
 Usage: exhort-javascript-api {component|stack}
 
@@ -112,16 +112,16 @@ Options:
 
 ```shell
 # get stack analysis in json format
-$ npx @RHEcosystemAppEng/exhort-javascript-api stack /path/to/pom.xml
+$ npx @trustification/exhort-javascript-api stack /path/to/pom.xml
 
 # get stack analysis in json format (summary only)
-$ npx @RHEcosystemAppEng/exhort-javascript-api stack /path/to/pom.xml --summary
+$ npx @trustification/exhort-javascript-api stack /path/to/pom.xml --summary
 
 # get stack analysis in html format format
-$ npx @RHEcosystemAppEng/exhort-javascript-api stack /path/to/pom.xml --html
+$ npx @trustification/exhort-javascript-api stack /path/to/pom.xml --html
 
 # get component analysis
-$ npx @RHEcosystemAppEng/exhort-javascript-api component /path/to/pom.xml
+$ npx @trustification/exhort-javascript-api component /path/to/pom.xml
 ```
 </li>
 
@@ -129,7 +129,7 @@ $ npx @RHEcosystemAppEng/exhort-javascript-api component /path/to/pom.xml
 Use as Global Binary
 
 ```shell
-npm install --global @RHEcosystemAppEng/exhort-javascript-api
+npm install --global @trustification/exhort-javascript-api
 ```
 
 ```shell
@@ -203,7 +203,7 @@ Excluding a package from any analysis can be achieved by marking the package for
 
 <em>Golang</em> users can add in go.mod a comment with //exhortignore next to the package to be ignored, or to "piggyback" on existing comment ( e.g - //indirect) , for example:
 ```go
-module github.com/RHEcosystemAppEng/SaaSi/deployer
+module github.com/trustification/SaaSi/deployer
 
 go 1.19
 
@@ -292,7 +292,7 @@ for various customization.
 However, <em>ESM Module</em> users, can opt for customizing programmatically:
 
 ```javascript
-import exhort from '@RHEcosystemAppEng/exhort-javascript-api'
+import exhort from '@trustification/exhort-javascript-api'
 import fs from 'node:fs'
 
 let options = {
@@ -444,8 +444,8 @@ It's also possible, to use lightweight Python PIP utility [pipdeptree](https://p
 Need to set environment variable/option - `EXHORT_PIP_USE_DEP_TREE` to true.
 
 <!-- Badge links -->
-[0]: https://img.shields.io/github/v/release/RHEcosystemAppEng/exhort-javascript-api?color=green&label=latest
-[1]: https://img.shields.io/github/v/release/RHEcosystemAppEng/exhort-javascript-api?color=yellow&include_prereleases&label=early-access
+[0]: https://img.shields.io/github/v/release/trustification/exhort-javascript-api?color=green&label=latest
+[1]: https://img.shields.io/github/v/release/trustification/exhort-javascript-api?color=yellow&include_prereleases&label=early-access
 
 ### Known Issues
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,11 +3,11 @@ kind: Component
 metadata:
   annotations:
     backstage.io/kubernetes-id: exhort-javascript-api
-    github.com/project-slug: RHEcosystemAppEng/exhort-javascript-api
+    github.com/project-slug: trustification/exhort-javascript-api
     github.com/project-readme-path: README.md
-    backstage.io/view-url: https://github.com/RHEcosystemAppEng/exhort-javascript-api/blob/main/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/RHEcosystemAppEng/exhort-javascript-api/blob/main/catalog-info.yaml
-    backstage.io/source-location: url:https://github.com/RHEcosystemAppEng/exhort-javascript-api
+    backstage.io/view-url: https://github.com/trustification/exhort-javascript-api/blob/main/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/trustification/exhort-javascript-api/blob/main/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/trustification/exhort-javascript-api
     rhda/manifest-file-path: package.json
     backstage.io/techdocs-ref: dir:README.md
   name: exhort-javascript-api

--- a/docker-image/Dockerfiles/Dockerfile
+++ b/docker-image/Dockerfiles/Dockerfile
@@ -20,14 +20,14 @@ RUN curl -kL https://go.dev/dl/go1.21.5.linux-amd64.tar.gz -o /tmp/golang-packag
     && tar xvzf /tmp/golang-package.tar.gz -C /usr/
 
 # install jq JSON formating tool
-RUN curl -kL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/bin/jq 
+RUN curl -kL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/bin/jq
 
 # copy the .npmrc file
 COPY configs/.npmrc .
 # replace placeholder with the actual environment variable
 RUN sed -i "s/__PACKAGE_REGISTRY_ACCESS_TOKEN__/${PACKAGE_REGISTRY_ACCESS_TOKEN}/g" ./.npmrc
 # install Exhort javascript API
-RUN npm install --global @RHEcosystemAppEng/exhort-javascript-api@0.1.1-ea.26
+RUN npm install --global @trustification/exhort-javascript-api@0.1.1-ea.26
 
 # add RHDA script
 COPY scripts/rhda.sh /rhda.sh
@@ -38,21 +38,21 @@ RUN chmod +x /usr/jdk-21.0.1/bin/java \
     && chmod +x /usr/go/bin/go \
     && chmod +x /usr/bin/jq \
     && chmod +x /opt/app-root/src/.npm-global/bin/exhort-javascript-api \
-    && chmod +x /rhda.sh 
+    && chmod +x /rhda.sh
 
 # use default user
-USER default 
+USER default
 
 # second stage
 FROM registry.access.redhat.com/ubi9/nodejs-20-minimal
 
-LABEL org.opencontainers.image.source https://github.com/RHEcosystemAppEng/exhort-javascript-api
+LABEL org.opencontainers.image.source https://github.com/trustification/exhort-javascript-api
 
 # assign rhda source for exhort tracking purposes
 ENV RHDA_SOURCE=''
-# contains pip feeze --all data, base64 encoded 
+# contains pip feeze --all data, base64 encoded
 ENV EXHORT_PIP_FREEZE=''
-# contains pip show data for all packages, base64 encoded 
+# contains pip show data for all packages, base64 encoded
 ENV EXHORT_PIP_SHOW=''
 # indicate whether to use the Minimal version selection (MVS) algorithm to select a set of module versions to use when building Go packages.
 ENV EXHORT_GO_MVS_LOGIC_ENABLED='false'

--- a/docker-image/configs/.npmrc
+++ b/docker-image/configs/.npmrc
@@ -1,2 +1,2 @@
 //npm.pkg.github.com/:_authToken=__PACKAGE_REGISTRY_ACCESS_TOKEN__
-@RHEcosystemAppEng:registry=https://npm.pkg.github.com
+@trustification:registry=https://npm.pkg.github.com

--- a/integration/testers/cli/package.json
+++ b/integration/testers/cli/package.json
@@ -6,6 +6,6 @@
 	"type": "module",
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@RHEcosystemAppEng/exhort-javascript-api": "file:../../../"
+		"@trustification/exhort-javascript-api": "file:../../../"
 	}
 }

--- a/integration/testers/javascript/index.js
+++ b/integration/testers/javascript/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import exhort from '@RHEcosystemAppEng/exhort-javascript-api'
+import exhort from '@trustification/exhort-javascript-api'
 import process from 'node:process'
 
 const [,, ...args] = process.argv

--- a/integration/testers/javascript/package.json
+++ b/integration/testers/javascript/package.json
@@ -6,6 +6,6 @@
 	"type": "module",
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@RHEcosystemAppEng/exhort-javascript-api": "file:../../../"
+		"@trustification/exhort-javascript-api": "file:../../../"
 	}
 }

--- a/integration/testers/typescript/index.ts
+++ b/integration/testers/typescript/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import exhort from '@RHEcosystemAppEng/exhort-javascript-api'
+import exhort from '@trustification/exhort-javascript-api'
 import process from 'node:process'
 
 const [,, ...args] = process.argv

--- a/integration/testers/typescript/package.json
+++ b/integration/testers/typescript/package.json
@@ -10,7 +10,7 @@
 		"compile": "tsc -p tsconfig.json"
 	},
 	"dependencies": {
-		"@RHEcosystemAppEng/exhort-javascript-api": "file:../../../"
+		"@trustification/exhort-javascript-api": "file:../../../"
 	},
 	"devDependencies": {
 		"typescript": "^5.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@RHEcosystemAppEng/exhort-javascript-api",
+	"name": "@trustification/exhort-javascript-api",
 	"version": "0.1.1-ea.51",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@RHEcosystemAppEng/exhort-javascript-api",
+			"name": "@trustification/exhort-javascript-api",
 			"version": "0.1.1-ea.51",
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-	"name": "@RHEcosystemAppEng/exhort-javascript-api",
+	"name": "@trustification/exhort-javascript-api",
 	"version": "0.1.1-ea.51",
 	"description": "Code-Ready Dependency Analytics JavaScript API.",
 	"license": "Apache-2.0",
-	"homepage": "https://github.com/RHEcosystemAppEng/exhort-javascript-api#README.md",
-	"bugs": "https://github.com/RHEcosystemAppEng/exhort-javascript-api/issues",
-	"repository": "github:RHEcosystemAppEng/exhort-javascript-api",
+	"homepage": "https://github.com/trustification/exhort-javascript-api#README.md",
+	"bugs": "https://github.com/trustification/exhort-javascript-api/issues",
+	"repository": "github:trustification/exhort-javascript-api",
 	"publishConfig": {
 		"registry": "https://npm.pkg.github.com"
 	},
@@ -43,7 +43,7 @@
 		"precompile": "rm -rf dist",
 		"compile": "tsc -p tsconfig.json",
 		"pregen:backend": "rm -rf generated",
-		"gen:backend": "openapi-generator-cli generate -i https://raw.githubusercontent.com/RHEcosystemAppEng/exhort-api-spec/v1.0.3/api/v4/openapi.yaml -g typescript --global-property models --model-package backend -o generated",
+		"gen:backend": "openapi-generator-cli generate -i https://raw.githubusercontent.com/trustification/exhort-api-spec/v1.0.3/api/v4/openapi.yaml -g typescript --global-property models --model-package backend -o generated",
 		"postgen:backend": "cp test/it/tsconfig.json generated/backend/tsconfig.json ; find generated/backend -type f -exec sed -i \"/^import { HttpFile } from '..\\/http\\/http'/d\" {} + ; npm run compileintegration ",
 		"compileintegration": "bash -c \"cd generated/backend ; tsc -p tsconfig.json ; cd ../..\""
 	},


### PR DESCRIPTION
## Description

Does what it says on the tin. I _believe_ the old references in the github workflows were causing stage/release steps to be skipped e.g. https://github.com/trustification/exhort-javascript-api/actions/runs/14490379669/job/40645283356

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
