### PR TITLE
chore: use secrets.GITHUB_TOKEN for npm publish & creating GH release

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Publish package
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_MAVEN_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm publish
 
       - name: Commit and push package modifications
@@ -131,7 +131,7 @@ jobs:
       - name: Create a release
         uses: actions/github-script@v6.4.1
         with:
-          github-token: ${{ secrets.STAGING_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const repo_name = context.payload.repository.full_name
             const response = await github.request('POST /repos/' + repo_name + '/releases', {


### PR DESCRIPTION
## Description

Due to `npm error 403 403 Forbidden - PUT https://npm.pkg.github.com/@trustification%2fexhort-javascript-api - Permission permission_denied: create_package` when attempting to publish on a recent main commit. Confirmed that `secrets.GITHUB_TOKEN` should have permissions according to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
