### PR TITLE
chore: revert to RHEcosystemAppEng for installing exhort-javascript-api in docker image

### DIFF
--- a/docker-image/Dockerfiles/Dockerfile
+++ b/docker-image/Dockerfiles/Dockerfile
@@ -27,7 +27,8 @@ COPY configs/.npmrc .
 # replace placeholder with the actual environment variable
 RUN sed -i "s/__PACKAGE_REGISTRY_ACCESS_TOKEN__/${PACKAGE_REGISTRY_ACCESS_TOKEN}/g" ./.npmrc
 # install Exhort javascript API
-RUN npm install --global @trustification/exhort-javascript-api@0.1.1-ea.26
+# this still needs to reference RHEcosystemAppEng as packages dont seem to be redirected given the org change of the repo
+RUN npm install --global @RHEcosystemAppEng/exhort-javascript-api@0.1.1-ea.26
 
 # add RHDA script
 COPY scripts/rhda.sh /rhda.sh


### PR DESCRIPTION
## Description

It seems even though this repo was migrated from RHEcosystemAppEng org to trustification, packages published while in the old org can't be referenced with the new orgs namespace. So we'll have to keep it for this section where we reference an old version. Speaking of, why does this reference a hard-coded old version instead of tracking main? :thinking: 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
