### PR TITLE
build: update dockerfile to use provided exhort-javascript-api instead of hardcoded version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
           echo "base-tag=$(git describe | awk -F '-' '{print $1}')" >> "$GITHUB_OUTPUT"
           echo "full-tag=$(git describe)" >> "$GITHUB_OUTPUT"
 
-
       - name: get first tag in current development iteration according to base
         id: fetch-tag
         if: ${{ contains(steps.last-release.outputs.full-tag , '-ea.') }}
@@ -70,7 +69,6 @@ jobs:
           else
              echo "bump-part=major" >> "$GITHUB_OUTPUT"
           fi
-
 
       - name: Update package with new version
         id: bump
@@ -112,8 +110,6 @@ jobs:
               previous_tag_name: '${{ steps.fetch-tag.outputs.oldest-tag != ''  && steps.fetch-tag.outputs.oldest-tag  || steps.last-release.outputs.base-tag }}'
             })
             return response.data.body
-
-
 
       - name: Create a release
         uses: actions/github-script@v6.4.1

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -147,6 +147,7 @@ jobs:
             ${{ env.DOCKERFILE_PATH }}
           build-args: |
             PACKAGE_REGISTRY_ACCESS_TOKEN=${{ secrets.PACKAGE_REGISTRY_ACCESS_TOKEN }}
+            EXHORT_JAVASCRIPT_API_VERSION=${{ steps.bump.outputs.version }}
           context: docker-image
 
       - name: Push Image To Registry

--- a/docker-image/Dockerfiles/Dockerfile
+++ b/docker-image/Dockerfiles/Dockerfile
@@ -6,6 +6,7 @@ USER root
 
 # assign token for reading packages from github package registry
 ARG PACKAGE_REGISTRY_ACCESS_TOKEN=''
+ARG EXHORT_JAVASCRIPT_API_VERSION='0.1.1-ea.55'
 
 # install Java
 RUN curl -kL https://download.oracle.com/java/21/archive/jdk-21.0.1_linux-x64_bin.tar.gz -o /tmp/java-package.tar.gz \
@@ -27,8 +28,7 @@ COPY configs/.npmrc .
 # replace placeholder with the actual environment variable
 RUN sed -i "s/__PACKAGE_REGISTRY_ACCESS_TOKEN__/${PACKAGE_REGISTRY_ACCESS_TOKEN}/g" ./.npmrc
 # install Exhort javascript API
-# this still needs to reference RHEcosystemAppEng as packages dont seem to be redirected given the org change of the repo
-RUN npm install --global @RHEcosystemAppEng/exhort-javascript-api@0.1.1-ea.26
+RUN npm install --global @trustification/exhort-javascript-api@${EXHORT_JAVASCRIPT_API_VERSION}
 
 # add RHDA script
 COPY scripts/rhda.sh /rhda.sh

--- a/docker-image/configs/.npmrc
+++ b/docker-image/configs/.npmrc
@@ -1,2 +1,2 @@
 //npm.pkg.github.com/:_authToken=__PACKAGE_REGISTRY_ACCESS_TOKEN__
-@RHEcosystemAppEng:registry=https://npm.pkg.github.com
+@trustification:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Description

**Related issues (if any):** https://github.com/trustification/exhort-javascript-api/issues/176

- fixes: https://github.com/trustification/exhort-javascript-api/issues/176

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
