### PR TITLE
fix: use --prefix instead of --dir for npm provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
 		"fast-toml": "^0.5.4",
 		"fast-xml-parser": "^4.2.4",
 		"help": "^3.0.2",
+		"node-fetch": "^2.6.7",
 		"packageurl-js": "^1.0.2",
-		"yargs": "^17.7.2",
-		"node-fetch": "^2.6.7"
+		"yargs": "^17.7.2"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.2",

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,26 @@ export function testSelectExhortBackend(opts) {
 let theUrl
 
 /**
+ * @overload
+ * @param {string} manifest
+ * @param {true} html
+ * @param {object} [opts={}]
+ * @returns {Promise<string>}
+ * @throws {Error}
+ */
+
+/**
+ * @overload
+ * @param {string} manifest
+ * @param {false} html
+ * @param {object} [opts={}]
+ * @returns {Promise<AnalysisReport>}
+ * @throws {Error}
+ */
+
+/**
  * Get stack analysis report for a manifest file.
+ * @overload
  * @param {string} manifest - path for the manifest
  * @param {boolean} [html=false] - true will return a html string, false will return AnalysisReport
  * @param {{}} [opts={}] - optional various options to pass along the application

--- a/src/providers/javascript_npm.js
+++ b/src/providers/javascript_npm.js
@@ -21,7 +21,7 @@ export default class Javascript_npm extends Base_javascript {
 	_updateLockFileCmdArgs(manifestDir) {
 		const args = ['install', '--package-lock-only']
 		if (manifestDir) {
-			args.push('--dir', manifestDir)
+			args.push('--prefix', manifestDir)
 		}
 		return args;
 	}


### PR DESCRIPTION
## Description

Also added type signature overloads for stack analysis function to narrow the return type based on if HTML report is requested or not

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
