### PR TITLE
fix: ignore reference to 'go@version' from newer `go mod graph` output

### DIFF
--- a/src/providers/golang_gomodules.js
+++ b/src/providers/golang_gomodules.js
@@ -262,7 +262,9 @@ function getSBOM(manifest, opts = {}, includeTransitive) {
 	let ignoredDeps = getIgnoredDeps(manifest);
 	let allIgnoredDeps = ignoredDeps.map((dep) => dep.toString())
 	let sbom = new Sbom();
-	let rows = goGraphOutput.split(getLineSeparatorGolang());
+	let rows = goGraphOutput.split(getLineSeparatorGolang()).filter(line => {
+		return !line.includes(' go@');
+	});
 	let root = getParentVertexFromEdge(rows[0])
 	let matchManifestVersions = getCustom("MATCH_MANIFEST_VERSIONS", "false", opts);
 	if(matchManifestVersions === "true") {


### PR DESCRIPTION
## Description

**Related issues (if any):** https://github.com/trustification/exhort-javascript-api/issues/184#issuecomment-2829592456

- fixes: https://github.com/trustification/exhort-javascript-api/issues/184#issuecomment-2829592456

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
