### PR TITLE
fix: address self-adding of npm workspace to package.json

### DIFF
--- a/src/providers/javascript_npm.js
+++ b/src/providers/javascript_npm.js
@@ -12,7 +12,7 @@ export default class Javascript_npm extends Base_javascript {
 
 	_listCmdArgs(includeTransitive, manifestDir) {
 		const args = ['ls', includeTransitive ? '--all' : '--depth=0', '--package-lock-only', '--omit=dev', '--json']
-		if (manifestDir) {
+		if (manifestDir && process.platform !== 'win32') {
 			args.push('--prefix', manifestDir)
 		}
 		return args
@@ -20,7 +20,7 @@ export default class Javascript_npm extends Base_javascript {
 
 	_updateLockFileCmdArgs(manifestDir) {
 		const args = ['install', '--package-lock-only']
-		if (manifestDir) {
+		if (manifestDir && process.platform !== 'win32') {
 			args.push('--prefix', manifestDir)
 		}
 		return args;


### PR DESCRIPTION
## Description

The `--prefix` flag is known to not work on windows. The original fix for this was to `os.chdir` to the path, perform install operation, and then reset cwd. This worked but had a side effect of adding a self-reference to the package.json. By removing the `--prefix` flag entirely on windows, the problem is addressed for some reason

- fixes: 
  https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/731
  https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/732
  https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/738
  https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/739

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
