### PR TITLE
chore(ci): update workflow triggers for releases

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,23 +9,21 @@ env:
 
 on:
   workflow_dispatch:
-  pull_request_target:
-    types:
-      - closed
-    branches:
-      - 'main'
-    paths:
-      - "src/**"
-      - "package-lock.json"
-      - "package.json"
-      - "tsconfig.json"
-      - ".github/workflows/release.yml"
+    inputs:
+      version_type:
+        description: 'Type of version bump'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   release:
     runs-on: ubuntu-latest
     environment: staging
-    if: github.repository_owner == 'trustification' && github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/' )
     name: Release the project
     steps:
       - name: Checkout sources
@@ -65,15 +63,9 @@ jobs:
           echo "oldest-tag=$(git for-each-ref --sort=creatordate --format '%(refname:lstrip=2)' refs/tags | grep ${{ steps.last-release.outputs.base-tag }} | head -n 1)" >> "$GITHUB_OUTPUT"
 
       - name: determine semver component to bump
-        env:
-          BUMP_PART: ${{ contains(github.event.pull_request.title,'major') && 'major' || 'check-minor' }}
         id: bump-decision
         run: |
-          if [[ $BUMP_PART == 'check-minor' ]]; then
-             echo "bump-part=${{ contains(github.event.pull_request.title,'minor') && 'minor' || 'patch' }}" >> "$GITHUB_OUTPUT"
-          else
-             echo "bump-part=major" >> "$GITHUB_OUTPUT"
-          fi
+          echo "bump-part=${{ github.event.inputs.version_type }}" >> "$GITHUB_OUTPUT"
 
       - name: Update package with new version
         id: bump

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -95,13 +95,7 @@ jobs:
       - name: Update package with new version
         id: bump
         run: |
-          if [[ "${{ github.base_ref }}" =~ ^release/([0-9]+\.[0-9]+)\.x$ ]]; then
-            # For release branches, use the branch version with ea
-            echo "version=$(npm version ${BASH_REMATCH[1]}.0-ea.1 --no-git-tag-version)" >> "$GITHUB_OUTPUT"
-          else
-            # For main branch, just increment the ea version
-            echo "version=$(npm version prerelease --no-git-tag-version --preid ea)" >> "$GITHUB_OUTPUT"
-          fi
+          echo "version=$(npm version prerelease --no-git-tag-version --preid ea)" >> "$GITHUB_OUTPUT"
 
       - name: Install project modules
         run: npm ci

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -14,6 +14,7 @@ on:
 
     branches:
       - main
+      - 'release/*'
 
     paths:
       - "src/**"
@@ -94,7 +95,13 @@ jobs:
       - name: Update package with new version
         id: bump
         run: |
-          echo "version=$(npm version prerelease --no-git-tag-version --preid ea)" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.base_ref }}" =~ ^release/([0-9]+\.[0-9]+)\.x$ ]]; then
+            # For release branches, use the branch version with ea
+            echo "version=$(npm version ${BASH_REMATCH[1]}.0-ea.1 --no-git-tag-version)" >> "$GITHUB_OUTPUT"
+          else
+            # For main branch, just increment the ea version
+            echo "version=$(npm version prerelease --no-git-tag-version --preid ea)" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install project modules
         run: npm ci


### PR DESCRIPTION
## Description

It updates when a release can be triggered and allows to create `ea` versions for release branches as well.
Allowing multiple development versions: `0.2.1-ea.3` and `0.1.1-ea.74`
Also the release workflow will be manually triggered only.

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.
