### PR TITLE
fix: normalize yarn berry output parsing

### DIFF
--- a/src/providers/processors/yarn_berry_processor.js
+++ b/src/providers/processors/yarn_berry_processor.js
@@ -39,10 +39,10 @@ export default class Yarn_berry_processor extends Yarn_processor {
    * @returns {string} Properly formatted JSON string
    */
 	parseDepTreeOutput(output) {
-    // Normalize line endings to EOL regardless of platform
+		// Normalize line endings to EOL regardless of platform
 		const normalizedOutput = output.replace(/\r\n|\n/g, EOL);
 		const lines = normalizedOutput.split(EOL).filter(line => line.trim());
-    // Transform multiline JSON objects into a valid JSON array
+		// Transform multiline JSON objects into a valid JSON array
 		const outputArray = lines.join('').replaceAll('}{', '},{');
 		return `[${outputArray}]`;
 	}

--- a/src/providers/processors/yarn_berry_processor.js
+++ b/src/providers/processors/yarn_berry_processor.js
@@ -39,8 +39,11 @@ export default class Yarn_berry_processor extends Yarn_processor {
    * @returns {string} Properly formatted JSON string
    */
 	parseDepTreeOutput(output) {
-		// Transform output by removing line breaks and ensuring proper JSON array format
-		const outputArray = output.trim().split(EOL).join('').replaceAll('}{', '},{');
+    // Normalize line endings to EOL regardless of platform
+		const normalizedOutput = output.replace(/\r\n|\n/g, EOL);
+		const lines = normalizedOutput.split(EOL).filter(line => line.trim());
+    // Transform multiline JSON objects into a valid JSON array
+		const outputArray = lines.join('').replaceAll('}{', '},{');
 		return `[${outputArray}]`;
 	}
 


### PR DESCRIPTION
## Description

Yarn Berry on Windows platform returns Linux EOL output. This fix ensures all outputs are normalized.

**Related issues (if any):** 

- fixes: #179 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.
