### PR TITLE
fix: don't parse any value as number

### DIFF
--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -226,9 +226,7 @@ export default class Java_maven extends Base_java {
 		let parser = new XMLParser({
 			commentPropName: '#comment', // mark comments with #comment
 			isArray: (_, jpath) => 'project.dependencies.dependency' === jpath,
-			numberParseOptions: {
-				skipLike: /[0-9]+[.]0/
-			}
+			parseTagValue: false
 		})
 		// read manifest pom.xml file into buffer
 		let buf = fs.readFileSync(manifest)

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -137,3 +137,22 @@ suite('testing the java-maven data provider with modules', () => {
 
 	})
 }).beforeAll(() => clock = useFakeTimers(new Date('2023-08-07T00:00:00.000Z'))).afterAll(()=> {clock.restore()});
+
+suite('testing the java-maven version parsing in getDependencies', () => {
+	test('verify version parsing works correctly', async () => {
+		const testCase = 'pom_deps_with_ignore_version_from_property';
+		const javaMvnProvider = await createMockProvider(`test/providers/tst_manifests/maven/${testCase}`);
+
+		// Use provideComponent to test the version parsing through the public interface
+		const result = javaMvnProvider.provideComponent(`test/providers/tst_manifests/maven/${testCase}/pom.xml`);
+		const sbom = JSON.parse(result.content);
+
+		// Find the BouncyCastle dependency in the SBOM
+		const bouncyCastleDependency = sbom.dependencies.find(dep =>
+			dep.ref === 'pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80'
+		);
+
+		expect(bouncyCastleDependency).to.exist;
+		expect(bouncyCastleDependency.ref).to.equal('pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80');
+	});
+}).beforeAll(() => clock = useFakeTimers(new Date('2023-08-07T00:00:00.000Z'))).afterAll(()=> {clock.restore()});

--- a/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/component_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/component_analysis_expected_sbom.json
@@ -21,7 +21,26 @@
 			"purl": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
 			"type": "application",
 			"bom-ref": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
+		},
+		{
+			"group": "org.bouncycastle",
+			"name": "bcprov-jdk18on",
+			"version": "1.80",
+			"purl": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80"
 		}
 	],
-	"dependencies": []
+	"dependencies": [
+		{
+			"ref": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"dependsOn": [
+				"pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80",
+			"dependsOn": []
+		}
+	]
 }

--- a/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/effective-pom.xml
+++ b/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/effective-pom.xml
@@ -23,6 +23,11 @@
       <version>1.2.17</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.80</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/mvn_deptree.txt
+++ b/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/mvn_deptree.txt
@@ -1,1 +1,3 @@
 pom-with-deps-and-ignore:pom-with-dependency-not-ignored-for-tests:jar:0.0.1
++- log4j:log4j:jar:1.2.17:compile
+\- org.bouncycastle:bcprov-jdk18on:jar:1.80:compile

--- a/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/pom.xml
+++ b/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/pom.xml
@@ -17,6 +17,11 @@
       <artifactId>log4j</artifactId>
       <version>${log4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.80</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_deps_with_ignore_version_from_property/stack_analysis_expected_sbom.json
@@ -1,27 +1,46 @@
 {
-    "bomFormat": "CycloneDX",
-    "specVersion": "1.4",
-    "version": 1,
-    "metadata": {
-        "timestamp": "2023-08-07T00:00:00.000Z",
-        "component": {
-            "group": "pom-with-deps-and-ignore",
-            "name": "pom-with-dependency-not-ignored-for-tests",
-            "version": "0.0.1",
-            "purl": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
-            "type": "application",
-            "bom-ref": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
-        }
-    },
-    "components": [
-        {
-            "group": "pom-with-deps-and-ignore",
-            "name": "pom-with-dependency-not-ignored-for-tests",
-            "version": "0.0.1",
-            "purl": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
-            "type": "application",
-            "bom-ref": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
-        }
-    ],
-    "dependencies": []
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.4",
+	"version": 1,
+	"metadata": {
+		"timestamp": "2023-08-07T00:00:00.000Z",
+		"component": {
+			"group": "pom-with-deps-and-ignore",
+			"name": "pom-with-dependency-not-ignored-for-tests",
+			"version": "0.0.1",
+			"purl": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"type": "application",
+			"bom-ref": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
+		}
+	},
+	"components": [
+		{
+			"group": "pom-with-deps-and-ignore",
+			"name": "pom-with-dependency-not-ignored-for-tests",
+			"version": "0.0.1",
+			"purl": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"type": "application",
+			"bom-ref": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
+		},
+		{
+			"group": "org.bouncycastle",
+			"name": "bcprov-jdk18on",
+			"version": "1.80",
+			"purl": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80"
+		}
+	],
+	"dependencies": [
+		{
+			"ref": "pkg:maven/pom-with-deps-and-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"dependsOn": [
+				"pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.80",
+			"dependsOn": []
+		}
+	]
 }

--- a/test/providers/tst_manifests/maven/pom_with_multiple_modules/component_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_with_multiple_modules/component_analysis_expected_sbom.json
@@ -177,10 +177,10 @@
 		{
 			"group": "commons-configuration",
 			"name": "commons-configuration",
-			"version": "1.1",
-			"purl": "pkg:maven/commons-configuration/commons-configuration@1.1",
+			"version": "1.10",
+			"purl": "pkg:maven/commons-configuration/commons-configuration@1.10",
 			"type": "library",
-			"bom-ref": "pkg:maven/commons-configuration/commons-configuration@1.1"
+			"bom-ref": "pkg:maven/commons-configuration/commons-configuration@1.10"
 		},
 		{
 			"group": "com.squareup.okhttp3",
@@ -222,7 +222,7 @@
 				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
 				"pkg:maven/com.github.spotbugs/spotbugs-annotations@4.8.3",
 				"pkg:maven/javax.enterprise/cdi-api@2.0",
-				"pkg:maven/commons-configuration/commons-configuration@1.1",
+				"pkg:maven/commons-configuration/commons-configuration@1.10",
 				"pkg:maven/com.squareup.okhttp3/okhttp@4.12.0",
 				"pkg:maven/org.projectlombok/lombok@1.18.30"
 			]
@@ -304,7 +304,7 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/commons-configuration/commons-configuration@1.1",
+			"ref": "pkg:maven/commons-configuration/commons-configuration@1.10",
 			"dependsOn": []
 		},
 		{

--- a/test/providers/tst_manifests/maven/pom_with_multiple_modules/module4/pom.xml
+++ b/test/providers/tst_manifests/maven/pom_with_multiple_modules/module4/pom.xml
@@ -45,11 +45,6 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>2.16.0</version>
 		</dependency>
-
-
-
-
-
 	</dependencies>
 
 </project>


### PR DESCRIPTION
## Description

Fix a parsing problem affecting some Maven versions that are parsed as numbers

**Related issues (if any):** 

- fixes: https://github.com/trustification/exhort-javascript-api/issues/220

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.
