### PR TITLE
fix: problem with gradle and yarn version resolution

### DIFF
--- a/.esmockrc.js
+++ b/.esmockrc.js
@@ -1,0 +1,7 @@
+export default {
+  resolve: {
+    alias: {
+      '@hapi/joi': '@hapi/joi/dist/joi.js'
+    }
+  }
+} 

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,14 @@
+{
+  "require": ["esmock"],
+  "loader": "esmock",
+  "node-option": [
+    "experimental-specifier-resolution=node",
+    "experimental-loader=esmock"
+  ],
+  "extension": ["js"],
+  "ui": "tdd",
+  "check-leaks": false,
+  "color": true,
+  "fail-zero": true,
+  "recursive": true
+} 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"test": "c8 npm run tests",
 		"localtest": "EXHORT_PIP3_PATH=/home/zgrinber/python3.9/bin/pip3 EXHORT_PYTHON3_PATH=/home/zgrinber/python3.9/bin/python3 c8 npm run tests",
 		"postlocaltest": " git status | grep src/providers/ | grep rewire | xargs -i git clean -f {}",
-		"tests": "mocha --loader=esmock  --grep \"Integration Tests|.*analysis module.*\" --invert",
+		"tests": "mocha --config .mocharc.json --grep \"Integration Tests|.*analysis module.*\" --invert",
 		"tests:rep": "mocha --reporter-option maxDiffSize=0 --reporter json > unit-tests-result.json",
 		"integration-tests": "mocha --grep \"Integration Tests\"",
 		"precompile": "rm -rf dist",
@@ -104,5 +104,8 @@
 	},
 	"eslintIgnore": [
 		"index.js"
-	]
+	],
+	"resolutions": {
+		"@hapi/joi": "17.1.1"
+	}
 }

--- a/src/cyclone_dx_sbom.js
+++ b/src/cyclone_dx_sbom.js
@@ -6,10 +6,11 @@ import {PackageURL} from "packageurl-js";
  *
  * @param component {PackageURL}
  * @param type type of package - application or library
- * @return {{"bom-ref": string, name, purl: string, type, version}}
+ * @param scope scope of the component - runtime or compile
+ * @return {{"bom-ref": string, name, purl: string, type, version, scope}}
  * @private
  */
-function getComponent(component, type) {
+function getComponent(component, type, scope) {
 	let componentObject;
 	if(component instanceof PackageURL)
 	{
@@ -20,7 +21,8 @@ function getComponent(component, type) {
 				"version": component.version,
 				"purl": component.toString(),
 				"type": type,
-				"bom-ref": component.toString()
+				"bom-ref": component.toString(),
+				"scope": scope
 			}
 		}
 		else
@@ -30,7 +32,8 @@ function getComponent(component, type) {
 				"version": component.version,
 				"purl": component.toString(),
 				"type": type,
-				"bom-ref": component.toString()
+				"bom-ref": component.toString(),
+				"scope": scope
 			}
 		}
 	}
@@ -94,7 +97,7 @@ export default class CycloneDxSbom {
 	 * @param {PackageURL} targetRef - The target component (dependency)
 	 * @return {CycloneDxSbom} The updated SBOM
 	 */
-	addDependency(sourceRef, targetRef) {
+	addDependency(sourceRef, targetRef, scope) {
 		const sourcePurl = sourceRef.toString();
 		const targetPurl = targetRef.toString();
 
@@ -102,7 +105,7 @@ export default class CycloneDxSbom {
 		[sourceRef, targetRef].forEach((ref, index) => {
 			const purl = index === 0 ? sourcePurl : targetPurl;
 			if (this.getComponentIndex(purl) < 0) {
-				this.components.push(getComponent(ref, "library"));
+				this.components.push(getComponent(ref, "library", scope));
 			}
 		});
 

--- a/src/providers/java_gradle.js
+++ b/src/providers/java_gradle.js
@@ -35,58 +35,6 @@ function stripString(depPart) {
 	return depPart.replaceAll(/["']/g,"")
 }
 
-/** this function checks whether a line from `gradle dependencies` output contains a version or not
- *
- * @param line the line from `gradle dependencies` output.
- * @return {*|boolean}
- */
-function containsVersion(line) {
-	let lineStriped = line.replace("(n)","").trim()
-	return (lineStriped.match(/\W*[a-z0-9.-]+:[a-z0-9.-]+:[0-9]+[.][0-9]+(.[0-9]+)?(.*)?.*/)
-		|| lineStriped.match(/.*version:\s?(')?[0-9]+[.][0-9]+(.[0-9]+)?(')?/)) && !lineStriped.includes("libs.")
-}
-
-/** this function gets an array {@link arrayForSbom} containing direct deps from build.gradle, and checks for each direct dependency , if there is more than one version for that package,
- * that is, if there exists two different artifacts with the same group (namespace) + name ( artifact), but with different version.
- * if so, it checks to see which one of the versions is the correct one ( determined by result of gradle dependencies command in {@link theContent}) , and then it
- * just remove the other version.
- * @param {string[]} arrayForSbom an array containing the direct dependencies from build.gradle
- * @param {string} theContent multiline string that contains the output of gradle dependencies command.
- */
-function removeDuplicateIfExists(arrayForSbom,theContent) {
-	return dependency => {
-		let content = theContent
-		/** @typedef {PackageUrl}
-		 */
-		let depUrl = this.parseDep(dependency)
-		let depVersion
-		if(depUrl.version) {
-			depVersion = depUrl.version.trim()
-		}
-		let indexOfDuplicate = arrayForSbom.map(dep => this.parseDep(dep))
-			.findIndex(dep => dep.namespace === depUrl.namespace && dep.name === depUrl.name && dep.version !== depVersion)
-		let selfIndex = arrayForSbom.map(dep => this.parseDep(dep))
-			.findIndex(dep => dep.namespace === depUrl.namespace && dep.name === depUrl.name && dep.version === depVersion)
-		if (selfIndex && selfIndex!== indexOfDuplicate && indexOfDuplicate > -1) {
-			let duplicateDepVersion = this.parseDep(arrayForSbom[indexOfDuplicate])
-			// content.match(/.*1.2.16\W?->\W?1.2.17.*/)
-			let regex = new RegExp(`.*${depVersion}\\W?->\\W?${duplicateDepVersion.version}.*`)
-			if(content.match(regex)) {
-				arrayForSbom.splice(selfIndex, 1)
-			}
-			else {
-				let regex2 = new RegExp(`.*${duplicateDepVersion.version}\\W?->\\W?${depVersion}.*`)
-				if(content.match(regex2)) {
-					arrayForSbom.splice(indexOfDuplicate, 1)
-				}
-			}
-		}
-	};
-}
-
-const componentAnalysisConfigs = ["api", "implementation", "compileOnly","compileOnlyApi","runtimeOnly"];
-const stackAnalysisConfigs = ["runtimeClasspath","compileClasspath"];
-
 /**
  * This class provides common functionality for Groovy and Kotlin DSL files.
  */
@@ -153,6 +101,110 @@ export default class Java_gradle extends Base_java {
 	}
 
 	/**
+	 * @param {string} line - the line to parse
+	 * @returns {number} the depth of the dependency in the tree starting from 1. -1 if the line is not a dependency.
+	 * @private
+	 */
+	#getIndentationLevel(line) {
+		// If it is level 1
+		let match = line.match(/^[\\+-]/);
+		if (match) {
+			return 1;
+		}
+		// Count the groups of 4 spaces preceded by a pipe or 5 spaces
+		match = line.match(/\|    |     /g);
+		if (!match) return -1;
+		return match.length + 1;
+	}
+
+
+	#prepareLinesForParsingDependencyTree(lines) {
+		return lines
+			.filter(dep => dep.trim() !== "" && !dep.endsWith(" FAILED"))
+			.map(dependency => {
+				// Calculate depth from original line
+				const depth = this.#getIndentationLevel(dependency);
+				
+				// Now process the dependency line
+				let processedLine = dependency.replaceAll("|", "");
+				processedLine = processedLine.replaceAll(/\\---|\+---/g, "");
+				processedLine = processedLine.replaceAll(/:(.*):(.*) -> (.*)$/g, ":$1:$3");
+				processedLine = processedLine.replaceAll(/:(.*)\W*->\W*(.*)$/g, ":$1:$2");
+				processedLine = processedLine.replaceAll(/(.*):(.*):(.*)$/g, "$1:$2:jar:$3");
+				processedLine = processedLine.replaceAll(/(n)$/g, "");
+				processedLine = processedLine.replace(/\s*\(\*\)$/, '').trim();
+				
+				// Return both the processed line and its depth
+				return {
+					line: `${processedLine}:compile`,
+					depth: depth
+				};
+			});
+	}
+
+	/**
+	 * Process the dependency tree and add dependencies to the SBOM
+	 * @param {string[]} config - the configuration lines to process
+	 * @param {Object} parentPurl - the parent package URL
+	 * @param {Sbom} sbom - the SBOM object to add dependencies to
+	 * @param {Set} processedDeps - set of already processed dependencies
+	 * @param {string} scope - the dependency scope
+	 * @private
+	 */
+	#processDependencyTree(config, parentPurl, sbom, processedDeps, scope) {
+		const processedLines = this.#prepareLinesForParsingDependencyTree(config);
+		let parentStack = [parentPurl];
+
+		for (const {line, depth} of processedLines) {
+			if (line) {
+        const lastDepth = parentStack.length - 1;
+				if (depth <= lastDepth) {
+					// Going up - pop parents until we reach the correct level
+					parentStack = parentStack.slice(0, depth);
+				}
+				
+				const currentParent = parentStack[depth - 1];
+				const purl = this.parseDep(line);
+				purl.scope = scope;
+				
+				// Create a unique key for this dependency
+				const depKey = `${currentParent.namespace}:${currentParent.name}:${currentParent.version}->${purl.namespace}:${purl.name}:${purl.version}`;
+				
+				// Add dependency to SBOM if not already processed
+				if (!processedDeps.has(depKey)) {
+					processedDeps.add(depKey);
+          sbom.addDependency(currentParent, purl, scope);
+				}
+        parentStack.push(purl);
+			}
+		}
+	}
+
+  /**
+	 * Create a Dot Graph dependency tree for a manifest path.
+	 * @param {string} manifest - path for pom.xml
+	 * @param {{}} [opts={}] - optional various options to pass along the application
+	 * @returns {string} the Dot Graph content
+	 * @private
+	 */
+	#buildSbom(content, properties, manifestPath, opts = {}) {
+		let sbom = new Sbom();
+		let root = `${properties.group}:${properties[ROOT_PROJECT_KEY_NAME].match(/Root project '(.+)'/)[1]}:jar:${properties.version}`
+		let rootPurl = this.parseDep(root)
+		sbom.addRoot(rootPurl)
+		let ignoredDeps = this.#getIgnoredDeps(manifestPath);
+		
+		const [runtimeConfig, compileConfig] = this.#extractConfigurations(content);
+
+		const processedDeps = new Set();
+		
+		this.#processDependencyTree(runtimeConfig, rootPurl, sbom, processedDeps, 'required');
+		this.#processDependencyTree(compileConfig, rootPurl, sbom, processedDeps, 'optional');
+		
+		return sbom.filterIgnoredDepsIncludingVersion(ignoredDeps).getAsJsonString(opts);
+	}
+
+	/**
 	 * Create a Dot Graph dependency tree for a manifest path.
 	 * @param {string} manifest - path for pom.xml
 	 * @param {{}} [opts={}] - optional various options to pass along the application
@@ -166,7 +218,7 @@ export default class Java_gradle extends Base_java {
 		if (process.env["EXHORT_DEBUG"] === "true") {
 			console.log("Dependency tree that will be used as input for creating the BOM =>" + EOL + EOL + content)
 		}
-		let sbom = this.#buildSbomFileFromTextFormat(content, properties, stackAnalysisConfigs, manifest,opts)
+		let sbom = this.#buildSbom(content, properties, manifest, opts)
 		return sbom
 	}
 
@@ -216,19 +268,8 @@ export default class Java_gradle extends Base_java {
 	#getSbomForComponentAnalysis(manifestPath, opts = {}) {
 		let content = this.#getDependencies(manifestPath, opts)
 		let properties = this.#extractProperties(manifestPath, opts)
-		let configurationNames = componentAnalysisConfigs
 
-		// let configName
-		// for (let config of configurationNames) {
-		// 	let directDeps = this.#extractLines(content, config);
-		// 	if (directDeps.length > 0) {
-		// 		configName = config
-		// 		break
-		//
-		// 	}
-		// }
-
-		let sbom = this.#buildSbomFileFromTextFormat(content, properties, configurationNames, manifestPath, opts)
+		let sbom = this.#buildDirectDependenciesSbom(content, properties, manifestPath, opts)
 		return sbom
 
 	}
@@ -251,101 +292,84 @@ export default class Java_gradle extends Base_java {
 	}
 
 	/**
-	 * Utility function for looking up a dependency in a list of dependencies ignoring the "ignored"
-	 * field
-	 * @param dep {Dependency} dependency to look for
-	 * @param deps {[Dependency]} list of dependencies to look in
-	 * @returns boolean true if found dep in deps
+	 * Extracts runtime and compile configurations from the dependency tree
+	 * @param {string} content - the dependency tree content
+	 * @returns {[string[], string[]]} tuple of [runtimeConfig, compileConfig]
 	 * @private
 	 */
-	#dependencyIn(dep, deps) {
-		return deps.filter(d => dep.artifactId === d.artifactId && dep.groupId === d.groupId && dep.version === d.version && dep.scope === d.scope).length > 0
-	}
+	#extractConfigurations(content) {
+		const lines = content.split(EOL);
+		const configs = {
+			runtimeClasspath: [],
+			compileClasspath: []
+		};
+		let currentConfig = null;
+		let collecting = false;
 
-	#dependencyInExcludingVersion(dep, deps) {
-		return deps.filter(d => dep.artifactId === d.artifactId && dep.groupId === d.groupId && dep.scope === d.scope).length > 0
-	}
+		for (const line of lines) {
+			// Check for configuration start
+			if (line.startsWith('runtimeClasspath')) {
+				currentConfig = 'runtimeClasspath';
+				collecting = true;
+				continue;
+			} else if (line.startsWith('compileClasspath')) {
+				currentConfig = 'compileClasspath';
+				collecting = true;
+				continue;
+			}
 
+			// If we're not collecting or no config is set, skip
+			if (!collecting || !currentConfig) continue;
+
+			// Check for end of configuration
+			if (line.trim() === '') {
+				collecting = false;
+				currentConfig = null;
+				continue;
+			}
+
+			// Add line to current configuration
+			configs[currentConfig].push(line);
+		}
+
+		return [configs.runtimeClasspath, configs.compileClasspath];
+	}
+  
 	/**
 	 *
 	 * @param content {string} - content of the dependency tree received from gradle dependencies command
 	 * @param properties {Object} - properties of the gradle project.
-	 * @param configNames {string[]} - the configuration name of dependencies to include in sbom.
 	 * @return {string} return sbom json string of the build.gradle manifest file
 	 */
-	#buildSbomFileFromTextFormat(content, properties, configNames, manifestPath, opts = {}) {
+	#buildDirectDependenciesSbom(content, properties, manifestPath, opts = {}) {
 		let sbom = new Sbom();
 		let root = `${properties.group}:${properties[ROOT_PROJECT_KEY_NAME].match(/Root project '(.+)'/)[1]}:jar:${properties.version}`
 		let rootPurl = this.parseDep(root)
 		sbom.addRoot(rootPurl)
-		let lines = new Array()
-		// component analysis.
-		if (configNames !== stackAnalysisConfigs ) {
-			configNames.forEach(configName => {
-				let deps = this.#extractLines(content, configName)
-				lines = lines.concat(deps)
-			})
-			let arrayForSbom = this.#prepareLinesForParsingDependencyTree(lines);
-			if(arrayForSbom.length > 0 && !containsVersion(arrayForSbom[0])) {
-				arrayForSbom = arrayForSbom.slice(1)
-			}
-			arrayForSbom.forEach( removeDuplicateIfExists.call(this, arrayForSbom,content))
-			this.parseDependencyTree(root + ":compile", 0, arrayForSbom, sbom)
-		}
-		// stack analysis , takes both runtimeClasspath and compileClasspath dependencies
-		else {
-			configNames.forEach(configName => {
-				let lines = this.#extractLines(content, configName)
-				let arrayForSbom = this.#prepareLinesForParsingDependencyTree(lines);
-				if(arrayForSbom.length > 0 && !containsVersion(arrayForSbom[0])) {
-					arrayForSbom = arrayForSbom.slice(1)
-				}
-				this.parseDependencyTree(root + ":compile", 0, arrayForSbom, sbom)
-			})
-		}
-		// transform gradle dependency tree to the form of maven dependency tree to use common sbom build algorithm in Base_java parent */
-		let ignoredDeps = this.#getIgnoredDeps(manifestPath)
+		let ignoredDeps = this.#getIgnoredDeps(manifestPath);
+		
+		const [runtimeConfig, compileConfig] = this.#extractConfigurations(content);
+
+    let directDependencies = new Map();
+    this.#processDirectDependencies(runtimeConfig, directDependencies, 'required');
+    this.#processDirectDependencies(compileConfig, directDependencies, 'optional');
+    
+    directDependencies.forEach((scope, dep) => {
+      const purl = this.parseDep(dep);
+      purl.scope = scope;
+      sbom.addDependency(rootPurl, purl, scope);
+    });
+		
 		return sbom.filterIgnoredDepsIncludingVersion(ignoredDeps).getAsJsonString(opts);
 	}
 
-	#prepareLinesForParsingDependencyTree(lines) {
-		return lines.filter(dep => dep.trim() !== "" && !dep.endsWith(" FAILED")).map(dependency => dependency.replaceAll("---", "-").replaceAll("    ", "  "))
-			.map(dependency => dependency.replaceAll(/:(.*):(.*) -> (.*)$/g, ":$1:$3"))
-			.map(dependency => dependency.replaceAll(/:(.*)\W*->\W*(.*)$/g, ":$1:$2"))
-			.map(dependency => dependency.replaceAll(/(.*):(.*):(.*)$/g, "$1:$2:jar:$3"))
-			.map(dependency => dependency.replaceAll(/(n)$/g), "")
-			.map(dependency => `${dependency}:compile`);
-	}
-
-	/**
-	 *
-	 * @param {string}dependencies - gradle dependencies
-	 * @param startMarker - the start marker configuration for dependencies collection
-	 * @return {string[]} - An array of lines that match the parameter startMarker
-	 * @private
-	 */
-
-	#extractLines(dependencies, startMarker) {
-		let dependenciesList = dependencies.split(EOL);
-		let resultList = new Array()
-		let startFound = false
-		for (const dependency in dependenciesList) {
-			if (dependenciesList[dependency].startsWith(startMarker)) {
-				startFound = true
+  #processDirectDependencies(config, directDependencies, scope) {
+		const lines = this.#prepareLinesForParsingDependencyTree(config);
+		lines.forEach(({line, depth}) => {
+			if (depth === 1 && !directDependencies.has(line)) {
+				directDependencies.set(line, scope);
 			}
-
-			if (startFound && dependency.trim() !== "") {
-				if(startMarker === 'runtimeClasspath'  || startMarker === 'compileClasspath' || containsVersion(dependenciesList[dependency]) ) {
-					resultList.push(dependenciesList[dependency])
-				}
-			}
-
-			if (startFound && dependenciesList[dependency].trim() === "") {
-				break
-			}
-
-		}
-		return resultList
+		});
 	}
 
 	/**

--- a/src/sbom.js
+++ b/src/sbom.js
@@ -49,8 +49,8 @@ export default class Sbom {
 	 * @param {PackageURL} targetRef current dependency to add to Dependencies list of component sourceRef
 	 * @return Sbom
 	 */
-	addDependency(sourceRef, targetRef){
-		return this.sbomModel.addDependency(sourceRef, targetRef)
+	addDependency(sourceRef, targetRef, scope){
+		return this.sbomModel.addDependency(sourceRef, targetRef, scope)
 	}
 
 	/**

--- a/test/providers/java_gradle_kotlin.test.js
+++ b/test/providers/java_gradle_kotlin.test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai'
 import { useFakeTimers } from "sinon";
 
 import Java_gradle_kotlin from '../../src/providers/java_gradle_kotlin.js'
+import { compareSboms } from '../utils/sbom_utils.js';
 
 let clock
 
@@ -49,22 +50,15 @@ suite('testing the java-gradle-kotlin data provider', () => {
 			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/expected_stack_sbom.json`,).toString().trim()
 			let dependencyTreeTextContent = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/depTree.txt`,).toString()
 			let gradleProperties = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/gradle.properties`,).toString()
-			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
 			let mockedExecFunction = function(bin, args){
 				return getStubbedResponse(args, dependencyTreeTextContent, gradleProperties);
 			}
 			let javGradleProvider = new Java_gradle_kotlin()
 			Object.getPrototypeOf(Object.getPrototypeOf(javGradleProvider))._invokeCommand = mockedExecFunction
 			// invoke sut stack analysis for scenario manifest
-			let providedDataForStack =  javGradleProvider.provideStack(`test/providers/tst_manifests/gradle/${testCase}/build.gradle.kts`)
+			let providedDataForStack = javGradleProvider.provideStack(`test/providers/tst_manifests/gradle/${testCase}/build.gradle.kts`)
 			// verify returned data matches expectation
-			// expect(providedDataForStack).to.deep.equal({
-			// 	ecosystem: 'gradle',
-			// 	contentType: 'application/vnd.cyclonedx+json',
-			// 	content: expectedSbom
-			//		})
-			let beautifiedOutput = JSON.stringify(JSON.parse(providedDataForStack.content),null, 4);
-			expect(beautifiedOutput).to.deep.equal(expectedSbom)
+			compareSboms(providedDataForStack.content, expectedSbom);
 
 		// these test cases takes ~2500-2700 ms each pr >10000 in CI (for the first test-case)
 		}).timeout(process.env.GITHUB_ACTIONS ? 40000 : 10000)
@@ -72,8 +66,6 @@ suite('testing the java-gradle-kotlin data provider', () => {
 		test(`verify gradle data provided for component analysis with scenario ${scenario}`, async () => {
 			// load the expected list for the scenario
 			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/expected_component_sbom.json`,).toString().trim()
-			// read target manifest file
-			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
 			let dependencyTreeTextContent = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/depTree.txt`,).toString()
 			let gradleProperties = fs.readFileSync(`test/providers/tst_manifests/gradle/${testCase}/gradle.properties`,).toString()
 			let mockedExecFunction = function(bin, args){
@@ -82,14 +74,11 @@ suite('testing the java-gradle-kotlin data provider', () => {
 			let javaGradleProvider = new Java_gradle_kotlin()
 			Object.getPrototypeOf(Object.getPrototypeOf(javaGradleProvider))._invokeCommand = mockedExecFunction
 			// invoke sut component analysis for scenario manifest
-			let provdidedForComponent = javaGradleProvider.provideComponent(`test/providers/tst_manifests/gradle/${testCase}/build.gradle.kts`, {})
+			let providedForComponent = javaGradleProvider.provideComponent(`test/providers/tst_manifests/gradle/${testCase}/build.gradle.kts`, {})
 			// verify returned data matches expectation
-			let beautifiedOutput = JSON.stringify(JSON.parse(provdidedForComponent.content),null, 4);
-			expect(beautifiedOutput).to.deep.equal(expectedSbom)
+			compareSboms(providedForComponent.content, expectedSbom);
 			// these test cases takes ~1400-2000 ms each pr >10000 in CI (for the first test-case)
 		}).timeout(process.env.GITHUB_ACTIONS ? 15000 : 5000)
-		// these test cases takes ~1400-2000 ms each pr >10000 in CI (for the first test-case)
-
 	})
 }).beforeAll(() => clock = useFakeTimers(new Date('2023-08-07T00:00:00.000Z'))).afterAll(()=> {clock.restore()});
 

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -1,13 +1,13 @@
 import fs from 'fs'
+import { platform } from 'os';
 import path from 'path';
 
 import { expect } from 'chai'
 import esmock from 'esmock';
 import { useFakeTimers } from "sinon";
+import which from 'which';
 
 import Java_maven from '../../src/providers/java_maven.js'
-import which from 'which';
-import { platform } from 'os';
 
 let clock
 

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_full_specification/expected_component_sbom.json
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_full_specification/expected_component_sbom.json
@@ -28,6 +28,7 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final"
     },
     {
@@ -36,15 +37,17 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final"
     },
     {
       "group" : "io.quarkus",
       "name" : "quarkus-resteasy",
-      "version" : "2.13.5.Final",
-      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
+      "version" : "2.13.7.Final",
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final",
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final"
+      "scope": "required",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final"
     },
     {
       "group" : "io.quarkus",
@@ -52,6 +55,7 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final"
     },
     {
@@ -60,15 +64,17 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final"
     },
     {
       "group" : "io.quarkus",
       "name" : "quarkus-vertx-http",
-      "version" : "2.13.5.Final",
-      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+      "version" : "2.13.7.Final",
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final",
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final"
+      "scope": "required",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final"
     },
     {
       "group" : "io.quarkus",
@@ -76,6 +82,7 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final"
     },
     {
@@ -84,6 +91,7 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final"
     },
     {
@@ -92,6 +100,7 @@
       "version" : "2.0.2",
       "purl" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
     },
     {
@@ -100,6 +109,7 @@
       "version" : "2.13.7.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-multipart@2.13.7.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-multipart@2.13.7.Final"
     },
     {
@@ -108,6 +118,7 @@
       "version" : "2.0.2.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final",
       "type" : "library",
+			"scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final"
     }
   ],
@@ -117,10 +128,10 @@
       "dependsOn" : [
         "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
         "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
-        "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
+        "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final",
         "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
         "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
-        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final",
         "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
         "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
         "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
@@ -137,7 +148,7 @@
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final",
       "dependsOn" : [ ]
     },
     {
@@ -149,7 +160,7 @@
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final",
       "dependsOn" : [ ]
     },
     {

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_full_specification/expected_stack_sbom.json
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_full_specification/expected_stack_sbom.json
@@ -28,6 +28,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final"
 		},
 		{
@@ -36,6 +37,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final"
 		},
 		{
@@ -44,6 +46,7 @@
 			"version": "1.3.5",
 			"purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
 		},
 		{
@@ -52,6 +55,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
 		},
 		{
@@ -60,6 +64,7 @@
 			"version": "3.0.3",
 			"purl": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3"
 		},
 		{
@@ -68,6 +73,7 @@
 			"version": "1.2.5",
 			"purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
 		},
 		{
@@ -76,6 +82,7 @@
 			"version": "3.2.6",
 			"purl": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
 		},
 		{
@@ -84,6 +91,7 @@
 			"version": "1.3.3",
 			"purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
 		},
 		{
@@ -92,6 +100,7 @@
 			"version": "1.0",
 			"purl": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
 		},
 		{
@@ -100,6 +109,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.7.Final"
 		},
 		{
@@ -108,6 +118,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.7.Final"
 		},
 		{
@@ -116,6 +127,7 @@
 			"version": "2.12.3",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config@2.12.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.3"
 		},
 		{
@@ -124,6 +136,7 @@
 			"version": "2.12.3",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.3"
 		},
 		{
@@ -132,6 +145,7 @@
 			"version": "2.0.1",
 			"purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1"
 		},
 		{
@@ -140,6 +154,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
 		},
 		{
@@ -148,6 +163,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1"
 		},
 		{
@@ -156,6 +172,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
 		},
 		{
@@ -164,6 +181,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
 		},
 		{
@@ -172,6 +190,7 @@
 			"version": "3.5.0.Final",
 			"purl": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final"
 		},
 		{
@@ -180,6 +199,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1"
 		},
 		{
@@ -188,6 +208,7 @@
 			"version": "9.3",
 			"purl": "pkg:maven/org.ow2.asm/asm@9.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.3"
 		},
 		{
@@ -196,6 +217,7 @@
 			"version": "2.12.3",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.3"
 		},
 		{
@@ -204,6 +226,7 @@
 			"version": "1.0.10",
 			"purl": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
 		},
 		{
@@ -212,6 +235,7 @@
 			"version": "1.5.4.Final-format-001",
 			"purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
 		},
 		{
@@ -220,6 +244,7 @@
 			"version": "2.2.1.Final",
 			"purl": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final"
 		},
 		{
@@ -228,6 +253,7 @@
 			"version": "3.4.3.Final",
 			"purl": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
 		},
 		{
@@ -236,6 +262,7 @@
 			"version": "1.7.36",
 			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
 		},
 		{
@@ -244,6 +271,7 @@
 			"version": "1.2.0.Final",
 			"purl": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final"
 		},
 		{
@@ -252,6 +280,7 @@
 			"version": "22.3.0",
 			"purl": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0"
 		},
 		{
@@ -260,6 +289,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.7.Final"
 		},
 		{
@@ -268,6 +298,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
 		},
 		{
@@ -276,6 +307,7 @@
 			"version": "0.1.1",
 			"purl": "pkg:maven/io.github.crac/org-crac@0.1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.1"
 		},
 		{
@@ -284,6 +316,7 @@
 			"version": "0.0.9",
 			"purl": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
 		},
 		{
@@ -292,6 +325,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final"
 		},
 		{
@@ -300,6 +334,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-arc@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.7.Final"
 		},
 		{
@@ -308,6 +343,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus.arc/arc@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.7.Final"
 		},
 		{
@@ -316,6 +352,7 @@
 			"version": "1.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
 		},
 		{
@@ -324,6 +361,7 @@
 			"version": "1.0.3",
 			"purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
 		},
 		{
@@ -332,6 +370,7 @@
 			"version": "1.3",
 			"purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3"
 		},
 		{
@@ -340,6 +379,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource@2.13.5.Final"
 		},
 		{
@@ -348,6 +388,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-common@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-common@2.13.5.Final"
 		},
 		{
@@ -356,6 +397,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-credentials@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.7.Final"
 		},
 		{
@@ -364,6 +406,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final"
 		},
 		{
@@ -372,6 +415,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-transaction-annotations@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-transaction-annotations@2.13.5.Final"
 		},
 		{
@@ -380,6 +424,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.7.Final"
 		},
 		{
@@ -388,6 +433,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.7.Final"
 		},
 		{
@@ -396,6 +442,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
 		},
 		{
@@ -404,6 +451,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2"
 		},
 		{
@@ -412,6 +460,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2"
 		},
 		{
@@ -420,6 +469,7 @@
 			"version": "1.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
 		},
 		{
@@ -428,6 +478,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-jta@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-jta@1.2.2"
 		},
 		{
@@ -436,6 +487,7 @@
 			"version": "2.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-api@2.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-api@2.7.0"
 		},
 		{
@@ -444,6 +496,7 @@
 			"version": "2.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-mutiny@2.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-mutiny@2.7.0"
 		},
 		{
@@ -452,6 +505,7 @@
 			"version": "5.13.1.Alpha1",
 			"purl": "pkg:maven/org.jboss.narayana.jta/narayana-jta@5.13.1.Alpha1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.narayana.jta/narayana-jta@5.13.1.Alpha1"
 		},
 		{
@@ -460,6 +514,7 @@
 			"version": "7.6.1.Final",
 			"purl": "pkg:maven/org.jboss/jboss-transaction-spi@7.6.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss/jboss-transaction-spi@7.6.1.Final"
 		},
 		{
@@ -468,6 +523,7 @@
 			"version": "1.0.0.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@1.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@1.0.0.Final"
 		},
 		{
@@ -476,6 +532,7 @@
 			"version": "5.13.1.Alpha1",
 			"purl": "pkg:maven/org.jboss.narayana.jts/narayana-jts-integration@5.13.1.Alpha1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.narayana.jts/narayana-jts-integration@5.13.1.Alpha1"
 		},
 		{
@@ -484,6 +541,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-api@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-api@1.16"
 		},
 		{
@@ -492,6 +550,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-narayana@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-narayana@1.16"
 		},
 		{
@@ -500,6 +559,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-pool@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-pool@1.16"
 		},
 		{
@@ -508,6 +568,7 @@
 			"version": "5.6.14.Final",
 			"purl": "pkg:maven/org.hibernate/hibernate-core@5.6.14.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/hibernate-core@5.6.14.Final"
 		},
 		{
@@ -516,6 +577,7 @@
 			"version": "1.12.18",
 			"purl": "pkg:maven/net.bytebuddy/byte-buddy@1.12.18",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.12.18"
 		},
 		{
@@ -524,6 +586,7 @@
 			"version": "2.7.7",
 			"purl": "pkg:maven/antlr/antlr@2.7.7",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/antlr/antlr@2.7.7"
 		},
 		{
@@ -532,6 +595,7 @@
 			"version": "1.5.1",
 			"purl": "pkg:maven/com.fasterxml/classmate@1.5.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml/classmate@1.5.1"
 		},
 		{
@@ -540,6 +604,7 @@
 			"version": "5.1.2.Final",
 			"purl": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final"
 		},
 		{
@@ -548,6 +613,7 @@
 			"version": "5.6.14.Final",
 			"purl": "pkg:maven/org.hibernate/hibernate-graalvm@5.6.14.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/hibernate-graalvm@5.6.14.Final"
 		},
 		{
@@ -556,6 +622,7 @@
 			"version": "2.3.3-b02",
 			"purl": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.3-b02",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.3-b02"
 		},
 		{
@@ -564,6 +631,7 @@
 			"version": "2.3.3-b02",
 			"purl": "pkg:maven/org.glassfish.jaxb/txw2@2.3.3-b02",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.glassfish.jaxb/txw2@2.3.3-b02"
 		},
 		{
@@ -572,6 +640,7 @@
 			"version": "3.0.10",
 			"purl": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.10",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.10"
 		},
 		{
@@ -580,6 +649,7 @@
 			"version": "1.2.1",
 			"purl": "pkg:maven/com.sun.activation/jakarta.activation@1.2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.1"
 		},
 		{
@@ -588,6 +658,7 @@
 			"version": "2.0.0.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final"
 		},
 		{
@@ -596,6 +667,7 @@
 			"version": "2.2.3",
 			"purl": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3"
 		},
 		{
@@ -604,6 +676,7 @@
 			"version": "0.1.1",
 			"purl": "pkg:maven/org.hibernate/quarkus-local-cache@0.1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/quarkus-local-cache@0.1.1"
 		},
 		{
@@ -612,6 +685,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-caffeine@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-caffeine@2.13.5.Final"
 		},
 		{
@@ -620,6 +694,7 @@
 			"version": "2.9.3",
 			"purl": "pkg:maven/com.github.ben-manes.caffeine/caffeine@2.9.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.ben-manes.caffeine/caffeine@2.9.3"
 		},
 		{
@@ -628,6 +703,7 @@
 			"version": "2.10.0",
 			"purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.10.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.errorprone/error_prone_annotations@2.10.0"
 		},
 		{
@@ -636,6 +712,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final"
 		},
 		{
@@ -644,6 +721,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final"
 		},
 		{
@@ -652,6 +730,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.7.Final"
 		},
 		{
@@ -660,6 +739,7 @@
 			"version": "1.1.4.Final",
 			"purl": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
 		},
 		{
@@ -668,6 +748,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1"
 		},
 		{
@@ -676,6 +757,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-core@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.4"
 		},
 		{
@@ -684,6 +766,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-common@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-common@4.1.86.Final"
 		},
 		{
@@ -692,6 +775,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-buffer@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.86.Final"
 		},
 		{
@@ -700,6 +784,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-transport@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-transport@4.1.86.Final"
 		},
 		{
@@ -708,6 +793,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-resolver@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.86.Final"
 		},
 		{
@@ -716,6 +802,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-handler@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-handler@4.1.86.Final"
 		},
 		{
@@ -724,6 +811,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.86.Final"
 		},
 		{
@@ -732,6 +820,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-codec@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec@4.1.86.Final"
 		},
 		{
@@ -740,6 +829,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final"
 		},
 		{
@@ -748,6 +838,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final"
 		},
 		{
@@ -756,6 +847,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-http@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.86.Final"
 		},
 		{
@@ -764,6 +856,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-http2@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.86.Final"
 		},
 		{
@@ -772,6 +865,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final"
 		},
 		{
@@ -780,6 +874,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final"
 		},
 		{
@@ -788,6 +883,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4"
 		},
 		{
@@ -796,6 +892,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson/jackson-bom@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson/jackson-bom@2.13.4"
 		},
 		{
@@ -804,6 +901,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.4"
 		},
 		{
@@ -812,6 +910,7 @@
 			"version": "2.13.4.2",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.2"
 		},
 		{
@@ -820,6 +919,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.4"
 		},
 		{
@@ -828,6 +928,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.4"
 		},
 		{
@@ -836,6 +937,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.13.4"
 		},
 		{
@@ -844,6 +946,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.4"
 		},
 		{
@@ -852,6 +955,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.13.4"
 		},
 		{
@@ -860,6 +964,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.13.4"
 		},
 		{
@@ -868,6 +973,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.7.Final"
 		},
 		{
@@ -876,6 +982,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-web@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-web@4.3.4"
 		},
 		{
@@ -884,6 +991,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4"
 		},
 		{
@@ -892,6 +1000,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4"
 		},
 		{
@@ -900,6 +1009,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
 		},
 		{
@@ -908,6 +1018,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final"
 		},
 		{
@@ -916,6 +1027,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-netty@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.7.Final"
 		},
 		{
@@ -924,6 +1036,7 @@
 			"version": "1.7.1",
 			"purl": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
 		},
 		{
@@ -932,6 +1045,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.86.Final"
 		},
 		{
@@ -940,6 +1054,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.7.Final"
 		},
 		{
@@ -948,6 +1063,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
 		},
 		{
@@ -956,6 +1072,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0"
 		},
 		{
@@ -964,6 +1081,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
 		},
 		{
@@ -972,6 +1090,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4"
 		},
 		{
@@ -980,6 +1099,7 @@
 			"version": "5.5.0",
 			"purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
 		},
 		{
@@ -988,6 +1108,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0"
 		},
 		{
@@ -996,6 +1117,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0"
 		},
 		{
@@ -1004,6 +1126,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0"
 		},
 		{
@@ -1012,6 +1135,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0"
 		},
 		{
@@ -1020,6 +1144,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
 		},
 		{
@@ -1028,6 +1153,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4"
 		},
 		{
@@ -1036,6 +1162,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.7.Final"
 		},
 		{
@@ -1044,6 +1171,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.7.Final"
 		},
 		{
@@ -1052,6 +1180,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final"
 		},
 		{
@@ -1060,6 +1189,7 @@
 			"version": "2.0.1.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final"
 		},
 		{
@@ -1068,6 +1198,7 @@
 			"version": "2.0.1.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final"
 		},
 		{
@@ -1076,6 +1207,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final"
 		},
 		{
@@ -1084,6 +1216,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
 		},
 		{
@@ -1092,6 +1225,7 @@
 			"version": "0.1.0",
 			"purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0"
 		},
 		{
@@ -1100,6 +1234,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final"
 		},
 		{
@@ -1108,6 +1243,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jackson@2.13.5.Final"
 		},
 		{
@@ -1116,6 +1252,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-jackson2-provider@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-jackson2-provider@4.7.7.Final"
 		},
 		{
@@ -1124,6 +1261,7 @@
 			"version": "1.13",
 			"purl": "pkg:maven/com.github.java-json-tools/json-patch@1.13",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/json-patch@1.13"
 		},
 		{
@@ -1132,6 +1270,7 @@
 			"version": "1.2",
 			"purl": "pkg:maven/com.github.java-json-tools/msg-simple@1.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/msg-simple@1.2"
 		},
 		{
@@ -1140,6 +1279,7 @@
 			"version": "1.3",
 			"purl": "pkg:maven/com.github.java-json-tools/btf@1.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/btf@1.3"
 		},
 		{
@@ -1148,6 +1288,7 @@
 			"version": "2.0",
 			"purl": "pkg:maven/com.github.java-json-tools/jackson-coreutils@2.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/jackson-coreutils@2.0"
 		},
 		{
@@ -1156,6 +1297,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final"
 		},
 		{
@@ -1164,6 +1306,7 @@
 			"version": "42.5.0",
 			"purl": "pkg:maven/org.postgresql/postgresql@42.5.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.postgresql/postgresql@42.5.0"
 		},
 		{
@@ -1172,6 +1315,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final"
 		},
 		{
@@ -1180,6 +1324,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final"
 		},
 		{
@@ -1188,6 +1333,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image@2.13.5.Final"
 		},
 		{
@@ -1196,6 +1342,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-multipart@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-multipart@2.13.7.Final"
 		},
 		{
@@ -1204,6 +1351,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-multipart-provider@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-multipart-provider@4.7.7.Final"
 		},
 		{
@@ -1212,6 +1360,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-jaxb-provider@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-jaxb-provider@4.7.7.Final"
 		},
 		{
@@ -1220,6 +1369,7 @@
 			"version": "1.6.5",
 			"purl": "pkg:maven/com.sun.mail/jakarta.mail@1.6.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.mail/jakarta.mail@1.6.5"
 		},
 		{
@@ -1228,6 +1378,7 @@
 			"version": "0.8.3",
 			"purl": "pkg:maven/org.apache.james/apache-mime4j-dom@0.8.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.james/apache-mime4j-dom@0.8.3"
 		},
 		{
@@ -1236,6 +1387,7 @@
 			"version": "0.8.3",
 			"purl": "pkg:maven/org.apache.james/apache-mime4j-core@0.8.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.james/apache-mime4j-core@0.8.3"
 		},
 		{
@@ -1244,6 +1396,7 @@
 			"version": "0.8.3",
 			"purl": "pkg:maven/org.apache.james/apache-mime4j-storage@0.8.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.james/apache-mime4j-storage@0.8.3"
 		},
 		{
@@ -1252,6 +1405,7 @@
 			"version": "2.6",
 			"purl": "pkg:maven/commons-io/commons-io@2.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/commons-io/commons-io@2.6"
 		},
 		{
@@ -1260,6 +1414,7 @@
 			"version": "1.0.0.Final",
 			"purl": "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final"
 		},
 		{
@@ -1268,6 +1423,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final"
 		},
 		{
@@ -1276,6 +1432,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-core-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-core-deployment@2.0.2.Final"
 		},
 		{
@@ -1284,6 +1441,7 @@
 			"version": "2.1",
 			"purl": "pkg:maven/org.aesh/readline@2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.aesh/readline@2.1"
 		},
 		{
@@ -1292,6 +1450,7 @@
 			"version": "1.18",
 			"purl": "pkg:maven/org.fusesource.jansi/jansi@1.18",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.fusesource.jansi/jansi@1.18"
 		},
 		{
@@ -1300,6 +1459,7 @@
 			"version": "3.12.0",
 			"purl": "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.12.0"
 		},
 		{
@@ -1308,6 +1468,7 @@
 			"version": "1.0.9.Final",
 			"purl": "pkg:maven/io.quarkus.gizmo/gizmo@1.0.9.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.gizmo/gizmo@1.0.9.Final"
 		},
 		{
@@ -1316,6 +1477,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-util@9.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-util@9.1"
 		},
 		{
@@ -1324,6 +1486,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-tree@9.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-tree@9.1"
 		},
 		{
@@ -1332,6 +1495,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-analysis@9.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-analysis@9.1"
 		},
 		{
@@ -1340,6 +1504,7 @@
 			"version": "2.3.0.Final",
 			"purl": "pkg:maven/org.jboss/jandex@2.3.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss/jandex@2.3.0.Final"
 		},
 		{
@@ -1348,6 +1513,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-class-change-agent@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-class-change-agent@2.0.2.Final"
 		},
 		{
@@ -1356,6 +1522,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-core@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-core@2.0.2.Final"
 		},
 		{
@@ -1364,6 +1531,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-app-model@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-app-model@2.0.2.Final"
 		},
 		{
@@ -1372,6 +1540,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-maven-resolver@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-maven-resolver@2.0.2.Final"
 		},
 		{
@@ -1380,6 +1549,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-embedder@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-embedder@3.8.1"
 		},
 		{
@@ -1388,6 +1558,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-settings@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-settings@3.8.1"
 		},
 		{
@@ -1396,6 +1567,7 @@
 			"version": "3.3.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0"
 		},
 		{
@@ -1404,6 +1576,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-settings-builder@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-settings-builder@3.8.1"
 		},
 		{
@@ -1412,6 +1585,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-builder-support@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-builder-support@3.8.1"
 		},
 		{
@@ -1420,6 +1594,7 @@
 			"version": "1.25",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.25",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.25"
 		},
 		{
@@ -1428,6 +1603,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/org.sonatype.plexus/plexus-sec-dispatcher@1.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.sonatype.plexus/plexus-sec-dispatcher@1.4"
 		},
 		{
@@ -1436,6 +1612,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/org.sonatype.plexus/plexus-cipher@1.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.sonatype.plexus/plexus-cipher@1.4"
 		},
 		{
@@ -1444,6 +1621,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-core@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-core@3.8.1"
 		},
 		{
@@ -1452,6 +1630,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-model@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-model@3.8.1"
 		},
 		{
@@ -1460,6 +1639,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-repository-metadata@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-repository-metadata@3.8.1"
 		},
 		{
@@ -1468,6 +1648,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-artifact@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-artifact@3.8.1"
 		},
 		{
@@ -1476,6 +1657,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-plugin-api@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-plugin-api@3.8.1"
 		},
 		{
@@ -1484,6 +1666,7 @@
 			"version": "0.3.4",
 			"purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.4"
 		},
 		{
@@ -1492,6 +1675,7 @@
 			"version": "2.1.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0"
 		},
 		{
@@ -1500,6 +1684,7 @@
 			"version": "2.6.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0"
 		},
 		{
@@ -1508,6 +1693,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-model-builder@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-model-builder@3.8.1"
 		},
 		{
@@ -1516,6 +1702,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-resolver-provider@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-resolver-provider@3.8.1"
 		},
 		{
@@ -1524,6 +1711,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.6.2"
 		},
 		{
@@ -1532,6 +1720,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.6.2"
 		},
 		{
@@ -1540,6 +1729,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.6.2"
 		},
 		{
@@ -1548,6 +1738,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.6.2"
 		},
 		{
@@ -1556,6 +1747,7 @@
 			"version": "3.2.1",
 			"purl": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.2.1"
 		},
 		{
@@ -1564,6 +1756,7 @@
 			"version": "4.2.1",
 			"purl": "pkg:maven/com.google.inject/guice@4.2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.inject/guice@4.2.1"
 		},
 		{
@@ -1572,6 +1765,7 @@
 			"version": "1.0",
 			"purl": "pkg:maven/aopalliance/aopalliance@1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/aopalliance/aopalliance@1.0"
 		},
 		{
@@ -1580,6 +1774,7 @@
 			"version": "25.1-android",
 			"purl": "pkg:maven/com.google.guava/guava@25.1-android",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.guava/guava@25.1-android"
 		},
 		{
@@ -1588,6 +1783,7 @@
 			"version": "3.0.2",
 			"purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
 		},
 		{
@@ -1596,6 +1792,7 @@
 			"version": "2.0.0",
 			"purl": "pkg:maven/org.checkerframework/checker-compat-qual@2.0.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.checkerframework/checker-compat-qual@2.0.0"
 		},
 		{
@@ -1604,6 +1801,7 @@
 			"version": "1.1",
 			"purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.j2objc/j2objc-annotations@1.1"
 		},
 		{
@@ -1612,6 +1810,7 @@
 			"version": "1.14",
 			"purl": "pkg:maven/org.codehaus.mojo/animal-sniffer-annotations@1.14",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.mojo/animal-sniffer-annotations@1.14"
 		},
 		{
@@ -1620,6 +1819,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/commons-cli/commons-cli@1.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/commons-cli/commons-cli@1.4"
 		},
 		{
@@ -1628,6 +1828,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.6.2"
 		},
 		{
@@ -1636,6 +1837,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.6.2"
 		},
 		{
@@ -1644,6 +1846,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-http@3.4.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http@3.4.3"
 		},
 		{
@@ -1652,6 +1855,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.4.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.4.3"
 		},
 		{
@@ -1660,6 +1864,7 @@
 			"version": "1.12.1",
 			"purl": "pkg:maven/org.jsoup/jsoup@1.12.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jsoup/jsoup@1.12.1"
 		},
 		{
@@ -1668,6 +1873,7 @@
 			"version": "4.5.13",
 			"purl": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13"
 		},
 		{
@@ -1676,6 +1882,7 @@
 			"version": "4.4.14",
 			"purl": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.14",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.14"
 		},
 		{
@@ -1684,6 +1891,7 @@
 			"version": "1.11",
 			"purl": "pkg:maven/commons-codec/commons-codec@1.11",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/commons-codec/commons-codec@1.11"
 		},
 		{
@@ -1692,6 +1900,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.4.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.4.3"
 		},
 		{
@@ -1700,6 +1909,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-file@3.4.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-file@3.4.3"
 		},
 		{
@@ -1708,6 +1918,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-gradle-resolver@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-gradle-resolver@2.0.2.Final"
 		},
 		{
@@ -1716,6 +1927,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-devtools-utilities@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-devtools-utilities@2.0.2.Final"
 		},
 		{
@@ -1724,6 +1936,7 @@
 			"version": "0.3.4",
 			"purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.4"
 		},
 		{
@@ -1732,6 +1945,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-builder@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-builder@2.0.2.Final"
 		},
 		{
@@ -1740,6 +1954,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-launcher@1.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-launcher@1.7.2"
 		},
 		{
@@ -1748,6 +1963,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit/junit-bom@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit/junit-bom@5.7.2"
 		},
 		{
@@ -1756,6 +1972,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.7.2"
 		},
 		{
@@ -1764,6 +1981,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.7.2"
 		},
 		{
@@ -1772,6 +1990,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.7.2"
 		},
 		{
@@ -1780,6 +1999,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.7.2"
 		},
 		{
@@ -1788,6 +2008,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.7.2"
 		},
 		{
@@ -1796,6 +2017,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2"
 		},
 		{
@@ -1804,6 +2026,7 @@
 			"version": "1.1.0",
 			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
 		},
 		{
@@ -1812,6 +2035,7 @@
 			"version": "1.2.0",
 			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
 		},
 		{
@@ -1820,6 +2044,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-narayana-jta-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-narayana-jta-deployment@2.0.2.Final"
 		},
 		{
@@ -1828,6 +2053,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-arc-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc-deployment@2.0.2.Final"
 		},
 		{
@@ -1836,6 +2062,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-spi@2.0.2.Final"
 		},
 		{
@@ -1844,6 +2071,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus.arc/arc-processor@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.arc/arc-processor@2.0.2.Final"
 		},
 		{
@@ -1852,6 +2080,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-mutiny-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny-deployment@2.0.2.Final"
 		},
 		{
@@ -1860,6 +2089,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation-deployment@2.0.2.Final"
 		},
 		{
@@ -1868,6 +2098,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal-deployment@2.0.2.Final"
 		},
 		{
@@ -1876,6 +2107,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-deployment@2.0.2.Final"
 		},
 		{
@@ -1884,6 +2116,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-deployment-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-deployment-spi@2.0.2.Final"
 		},
 		{
@@ -1892,6 +2125,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal-spi@2.0.2.Final"
 		},
 		{
@@ -1900,6 +2134,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-credentials-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials-deployment@2.0.2.Final"
 		},
 		{
@@ -1908,6 +2143,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-health-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-health-spi@2.0.2.Final"
 		},
 		{
@@ -1916,6 +2152,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-caffeine-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-caffeine-deployment@2.0.2.Final"
 		},
 		{
@@ -1924,6 +2161,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common-deployment@2.0.2.Final"
 		},
 		{
@@ -1932,6 +2170,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common@2.0.2.Final"
 		},
 		{
@@ -1940,6 +2179,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-common@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-common@2.0.2.Final"
 		},
 		{
@@ -1948,6 +2188,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-common-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-common-deployment@2.0.2.Final"
 		}
 	],

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/build.gradle
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation "io.quarkus:quarkus-hibernate-orm-deployment:2.0.2.Final"
     implementation group: 'log4j', name: 'log4j', version: '1.2.17' // exhortignore
     implementation "com.acme:invented.dependency:1.0.0"
+    implementation "org.zenframework.z8.dependencies.commons:log4j-1.2.17:1.10"
 
 }
 test {

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/expected_component_sbom.json
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/expected_component_sbom.json
@@ -28,6 +28,7 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final"
     },
     {
@@ -36,15 +37,17 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final"
     },
     {
       "group" : "io.quarkus",
       "name" : "quarkus-resteasy",
-      "version" : "2.13.5.Final",
-      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
+      "version" : "2.13.7.Final",
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final",
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final"
+      "scope": "required",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final"
     },
     {
       "group" : "io.quarkus",
@@ -52,6 +55,7 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final"
     },
     {
@@ -60,15 +64,17 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final"
     },
     {
       "group" : "io.quarkus",
       "name" : "quarkus-vertx-http",
-      "version" : "2.13.5.Final",
-      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+      "version" : "2.13.7.Final",
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final",
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final"
+      "scope": "required",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final"
     },
     {
       "group" : "io.quarkus",
@@ -76,6 +82,7 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final"
     },
     {
@@ -84,6 +91,7 @@
       "version" : "2.13.5.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final"
     },
     {
@@ -92,6 +100,7 @@
       "version" : "2.0.2",
       "purl" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
     },
     {
@@ -100,6 +109,7 @@
       "version" : "2.13.7.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-multipart@2.13.7.Final",
       "type" : "library",
+      "scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-multipart@2.13.7.Final"
     },
     {
@@ -108,6 +118,7 @@
       "version" : "2.0.2.Final",
       "purl" : "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final",
       "type" : "library",
+			"scope": "required",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final"
     }
   ],
@@ -117,10 +128,10 @@
       "dependsOn" : [
         "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
         "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
-        "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
+        "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final",
         "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
         "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
-        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final",
         "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
         "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
         "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
@@ -137,7 +148,7 @@
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final",
       "dependsOn" : [ ]
     },
     {
@@ -149,7 +160,7 @@
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final",
       "dependsOn" : [ ]
     },
     {

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/expected_stack_sbom.json
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/expected_stack_sbom.json
@@ -28,6 +28,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final"
 		},
 		{
@@ -36,6 +37,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final"
 		},
 		{
@@ -44,6 +46,7 @@
 			"version": "1.3.5",
 			"purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
 		},
 		{
@@ -52,6 +55,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
 		},
 		{
@@ -60,6 +64,7 @@
 			"version": "3.0.3",
 			"purl": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3"
 		},
 		{
@@ -68,6 +73,7 @@
 			"version": "1.2.5",
 			"purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
 		},
 		{
@@ -76,6 +82,7 @@
 			"version": "3.2.6",
 			"purl": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
 		},
 		{
@@ -84,6 +91,7 @@
 			"version": "1.3.3",
 			"purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
 		},
 		{
@@ -92,6 +100,7 @@
 			"version": "1.0",
 			"purl": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
 		},
 		{
@@ -100,6 +109,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.7.Final"
 		},
 		{
@@ -108,6 +118,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.7.Final"
 		},
 		{
@@ -116,6 +127,7 @@
 			"version": "2.12.3",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config@2.12.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.3"
 		},
 		{
@@ -124,6 +136,7 @@
 			"version": "2.12.3",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.3"
 		},
 		{
@@ -132,6 +145,7 @@
 			"version": "2.0.1",
 			"purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1"
 		},
 		{
@@ -140,6 +154,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
 		},
 		{
@@ -148,6 +163,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1"
 		},
 		{
@@ -156,6 +172,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
 		},
 		{
@@ -164,6 +181,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
 		},
 		{
@@ -172,6 +190,7 @@
 			"version": "3.5.0.Final",
 			"purl": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final"
 		},
 		{
@@ -180,6 +199,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1"
 		},
 		{
@@ -188,6 +208,7 @@
 			"version": "9.3",
 			"purl": "pkg:maven/org.ow2.asm/asm@9.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.3"
 		},
 		{
@@ -196,6 +217,7 @@
 			"version": "2.12.3",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.3"
 		},
 		{
@@ -204,6 +226,7 @@
 			"version": "1.0.10",
 			"purl": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
 		},
 		{
@@ -212,6 +235,7 @@
 			"version": "1.5.4.Final-format-001",
 			"purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
 		},
 		{
@@ -220,6 +244,7 @@
 			"version": "2.2.1.Final",
 			"purl": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final"
 		},
 		{
@@ -228,6 +253,7 @@
 			"version": "3.4.3.Final",
 			"purl": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
 		},
 		{
@@ -236,6 +262,7 @@
 			"version": "1.7.36",
 			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
 		},
 		{
@@ -244,6 +271,7 @@
 			"version": "1.2.0.Final",
 			"purl": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final"
 		},
 		{
@@ -252,6 +280,7 @@
 			"version": "22.3.0",
 			"purl": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0"
 		},
 		{
@@ -260,6 +289,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.7.Final"
 		},
 		{
@@ -268,6 +298,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
 		},
 		{
@@ -276,6 +307,7 @@
 			"version": "0.1.1",
 			"purl": "pkg:maven/io.github.crac/org-crac@0.1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.1"
 		},
 		{
@@ -284,6 +316,7 @@
 			"version": "0.0.9",
 			"purl": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
 		},
 		{
@@ -292,6 +325,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final"
 		},
 		{
@@ -300,6 +334,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-arc@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.7.Final"
 		},
 		{
@@ -308,6 +343,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus.arc/arc@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.7.Final"
 		},
 		{
@@ -316,6 +352,7 @@
 			"version": "1.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
 		},
 		{
@@ -324,6 +361,7 @@
 			"version": "1.0.3",
 			"purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
 		},
 		{
@@ -332,6 +370,7 @@
 			"version": "1.3",
 			"purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3"
 		},
 		{
@@ -340,6 +379,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource@2.13.5.Final"
 		},
 		{
@@ -348,6 +388,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-common@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-common@2.13.5.Final"
 		},
 		{
@@ -356,6 +397,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-credentials@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.7.Final"
 		},
 		{
@@ -364,6 +406,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final"
 		},
 		{
@@ -372,6 +415,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-transaction-annotations@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-transaction-annotations@2.13.5.Final"
 		},
 		{
@@ -380,6 +424,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.7.Final"
 		},
 		{
@@ -388,6 +433,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.7.Final"
 		},
 		{
@@ -396,6 +442,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
 		},
 		{
@@ -404,6 +451,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2"
 		},
 		{
@@ -412,6 +460,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2"
 		},
 		{
@@ -420,6 +469,7 @@
 			"version": "1.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
 		},
 		{
@@ -428,6 +478,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-jta@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-jta@1.2.2"
 		},
 		{
@@ -436,6 +487,7 @@
 			"version": "2.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-api@2.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-api@2.7.0"
 		},
 		{
@@ -444,6 +496,7 @@
 			"version": "2.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-mutiny@2.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-mutiny@2.7.0"
 		},
 		{
@@ -452,6 +505,7 @@
 			"version": "5.13.1.Alpha1",
 			"purl": "pkg:maven/org.jboss.narayana.jta/narayana-jta@5.13.1.Alpha1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.narayana.jta/narayana-jta@5.13.1.Alpha1"
 		},
 		{
@@ -460,6 +514,7 @@
 			"version": "7.6.1.Final",
 			"purl": "pkg:maven/org.jboss/jboss-transaction-spi@7.6.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss/jboss-transaction-spi@7.6.1.Final"
 		},
 		{
@@ -468,6 +523,7 @@
 			"version": "1.0.0.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@1.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@1.0.0.Final"
 		},
 		{
@@ -476,6 +532,7 @@
 			"version": "5.13.1.Alpha1",
 			"purl": "pkg:maven/org.jboss.narayana.jts/narayana-jts-integration@5.13.1.Alpha1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.narayana.jts/narayana-jts-integration@5.13.1.Alpha1"
 		},
 		{
@@ -484,6 +541,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-api@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-api@1.16"
 		},
 		{
@@ -492,6 +550,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-narayana@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-narayana@1.16"
 		},
 		{
@@ -500,6 +559,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-pool@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-pool@1.16"
 		},
 		{
@@ -508,6 +568,7 @@
 			"version": "5.6.14.Final",
 			"purl": "pkg:maven/org.hibernate/hibernate-core@5.6.14.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/hibernate-core@5.6.14.Final"
 		},
 		{
@@ -516,6 +577,7 @@
 			"version": "1.12.18",
 			"purl": "pkg:maven/net.bytebuddy/byte-buddy@1.12.18",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.12.18"
 		},
 		{
@@ -524,6 +586,7 @@
 			"version": "2.7.7",
 			"purl": "pkg:maven/antlr/antlr@2.7.7",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/antlr/antlr@2.7.7"
 		},
 		{
@@ -532,6 +595,7 @@
 			"version": "1.5.1",
 			"purl": "pkg:maven/com.fasterxml/classmate@1.5.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml/classmate@1.5.1"
 		},
 		{
@@ -540,6 +604,7 @@
 			"version": "5.1.2.Final",
 			"purl": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final"
 		},
 		{
@@ -548,6 +613,7 @@
 			"version": "5.6.14.Final",
 			"purl": "pkg:maven/org.hibernate/hibernate-graalvm@5.6.14.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/hibernate-graalvm@5.6.14.Final"
 		},
 		{
@@ -556,6 +622,7 @@
 			"version": "2.3.3-b02",
 			"purl": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.3-b02",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.3-b02"
 		},
 		{
@@ -564,6 +631,7 @@
 			"version": "2.3.3-b02",
 			"purl": "pkg:maven/org.glassfish.jaxb/txw2@2.3.3-b02",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.glassfish.jaxb/txw2@2.3.3-b02"
 		},
 		{
@@ -572,6 +640,7 @@
 			"version": "3.0.10",
 			"purl": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.10",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.10"
 		},
 		{
@@ -580,6 +649,7 @@
 			"version": "1.2.1",
 			"purl": "pkg:maven/com.sun.activation/jakarta.activation@1.2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.1"
 		},
 		{
@@ -588,6 +658,7 @@
 			"version": "2.0.0.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final"
 		},
 		{
@@ -596,6 +667,7 @@
 			"version": "2.2.3",
 			"purl": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3"
 		},
 		{
@@ -604,6 +676,7 @@
 			"version": "0.1.1",
 			"purl": "pkg:maven/org.hibernate/quarkus-local-cache@0.1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/quarkus-local-cache@0.1.1"
 		},
 		{
@@ -612,6 +685,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-caffeine@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-caffeine@2.13.5.Final"
 		},
 		{
@@ -620,6 +694,7 @@
 			"version": "2.9.3",
 			"purl": "pkg:maven/com.github.ben-manes.caffeine/caffeine@2.9.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.ben-manes.caffeine/caffeine@2.9.3"
 		},
 		{
@@ -628,6 +703,7 @@
 			"version": "2.10.0",
 			"purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.10.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.errorprone/error_prone_annotations@2.10.0"
 		},
 		{
@@ -636,6 +712,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final"
 		},
 		{
@@ -644,6 +721,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.7.Final"
 		},
 		{
@@ -652,6 +730,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.7.Final"
 		},
 		{
@@ -660,6 +739,7 @@
 			"version": "1.1.4.Final",
 			"purl": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
 		},
 		{
@@ -668,6 +748,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1"
 		},
 		{
@@ -676,6 +757,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-core@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.4"
 		},
 		{
@@ -684,6 +766,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-common@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-common@4.1.86.Final"
 		},
 		{
@@ -692,6 +775,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-buffer@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.86.Final"
 		},
 		{
@@ -700,6 +784,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-transport@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-transport@4.1.86.Final"
 		},
 		{
@@ -708,6 +793,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-resolver@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.86.Final"
 		},
 		{
@@ -716,6 +802,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-handler@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-handler@4.1.86.Final"
 		},
 		{
@@ -724,6 +811,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.86.Final"
 		},
 		{
@@ -732,6 +820,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-codec@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec@4.1.86.Final"
 		},
 		{
@@ -740,6 +829,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final"
 		},
 		{
@@ -748,6 +838,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final"
 		},
 		{
@@ -756,6 +847,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-http@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.86.Final"
 		},
 		{
@@ -764,6 +856,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-http2@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.86.Final"
 		},
 		{
@@ -772,6 +865,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final"
 		},
 		{
@@ -780,6 +874,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final"
 		},
 		{
@@ -788,6 +883,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4"
 		},
 		{
@@ -796,6 +892,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson/jackson-bom@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson/jackson-bom@2.13.4"
 		},
 		{
@@ -804,6 +901,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.4"
 		},
 		{
@@ -812,6 +910,7 @@
 			"version": "2.13.4.2",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.2"
 		},
 		{
@@ -820,6 +919,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.4"
 		},
 		{
@@ -828,6 +928,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.4"
 		},
 		{
@@ -836,6 +937,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.13.4"
 		},
 		{
@@ -844,6 +946,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.4"
 		},
 		{
@@ -852,6 +955,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.13.4"
 		},
 		{
@@ -860,6 +964,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.13.4"
 		},
 		{
@@ -868,6 +973,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.7.Final"
 		},
 		{
@@ -876,6 +982,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-web@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-web@4.3.4"
 		},
 		{
@@ -884,6 +991,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4"
 		},
 		{
@@ -892,6 +1000,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4"
 		},
 		{
@@ -900,6 +1009,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
 		},
 		{
@@ -908,6 +1018,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final"
 		},
 		{
@@ -916,6 +1027,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-netty@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.7.Final"
 		},
 		{
@@ -924,6 +1036,7 @@
 			"version": "1.7.1",
 			"purl": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
 		},
 		{
@@ -932,6 +1045,7 @@
 			"version": "4.1.86.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.86.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.86.Final"
 		},
 		{
@@ -940,6 +1054,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.7.Final"
 		},
 		{
@@ -948,6 +1063,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
 		},
 		{
@@ -956,6 +1072,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0"
 		},
 		{
@@ -964,6 +1081,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
 		},
 		{
@@ -972,6 +1090,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4"
 		},
 		{
@@ -980,6 +1099,7 @@
 			"version": "5.5.0",
 			"purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
 		},
 		{
@@ -988,6 +1108,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0"
 		},
 		{
@@ -996,6 +1117,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0"
 		},
 		{
@@ -1004,6 +1126,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0"
 		},
 		{
@@ -1012,6 +1135,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0"
 		},
 		{
@@ -1020,6 +1144,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
 		},
 		{
@@ -1028,6 +1153,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4"
 		},
 		{
@@ -1036,6 +1162,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.7.Final"
 		},
 		{
@@ -1044,6 +1171,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.7.Final"
 		},
 		{
@@ -1052,6 +1180,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final"
 		},
 		{
@@ -1060,6 +1189,7 @@
 			"version": "2.0.1.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final"
 		},
 		{
@@ -1068,6 +1198,7 @@
 			"version": "2.0.1.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final"
 		},
 		{
@@ -1076,6 +1207,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final"
 		},
 		{
@@ -1084,6 +1216,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
 		},
 		{
@@ -1092,6 +1225,7 @@
 			"version": "0.1.0",
 			"purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0"
 		},
 		{
@@ -1100,6 +1234,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final"
 		},
 		{
@@ -1108,6 +1243,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jackson@2.13.5.Final"
 		},
 		{
@@ -1116,6 +1252,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-jackson2-provider@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-jackson2-provider@4.7.7.Final"
 		},
 		{
@@ -1124,6 +1261,7 @@
 			"version": "1.13",
 			"purl": "pkg:maven/com.github.java-json-tools/json-patch@1.13",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/json-patch@1.13"
 		},
 		{
@@ -1132,6 +1270,7 @@
 			"version": "1.2",
 			"purl": "pkg:maven/com.github.java-json-tools/msg-simple@1.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/msg-simple@1.2"
 		},
 		{
@@ -1140,6 +1279,7 @@
 			"version": "1.3",
 			"purl": "pkg:maven/com.github.java-json-tools/btf@1.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/btf@1.3"
 		},
 		{
@@ -1148,6 +1288,7 @@
 			"version": "2.0",
 			"purl": "pkg:maven/com.github.java-json-tools/jackson-coreutils@2.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/jackson-coreutils@2.0"
 		},
 		{
@@ -1156,6 +1297,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final"
 		},
 		{
@@ -1164,6 +1306,7 @@
 			"version": "42.5.0",
 			"purl": "pkg:maven/org.postgresql/postgresql@42.5.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.postgresql/postgresql@42.5.0"
 		},
 		{
@@ -1172,6 +1315,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final"
 		},
 		{
@@ -1180,6 +1324,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final"
 		},
 		{
@@ -1188,6 +1333,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image@2.13.5.Final"
 		},
 		{
@@ -1196,6 +1342,7 @@
 			"version": "2.13.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-multipart@2.13.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-multipart@2.13.7.Final"
 		},
 		{
@@ -1204,6 +1351,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-multipart-provider@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-multipart-provider@4.7.7.Final"
 		},
 		{
@@ -1212,6 +1360,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-jaxb-provider@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-jaxb-provider@4.7.7.Final"
 		},
 		{
@@ -1220,6 +1369,7 @@
 			"version": "1.6.5",
 			"purl": "pkg:maven/com.sun.mail/jakarta.mail@1.6.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.mail/jakarta.mail@1.6.5"
 		},
 		{
@@ -1228,6 +1378,7 @@
 			"version": "0.8.3",
 			"purl": "pkg:maven/org.apache.james/apache-mime4j-dom@0.8.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.james/apache-mime4j-dom@0.8.3"
 		},
 		{
@@ -1236,6 +1387,7 @@
 			"version": "0.8.3",
 			"purl": "pkg:maven/org.apache.james/apache-mime4j-core@0.8.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.james/apache-mime4j-core@0.8.3"
 		},
 		{
@@ -1244,6 +1396,7 @@
 			"version": "0.8.3",
 			"purl": "pkg:maven/org.apache.james/apache-mime4j-storage@0.8.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.james/apache-mime4j-storage@0.8.3"
 		},
 		{
@@ -1252,6 +1405,7 @@
 			"version": "2.6",
 			"purl": "pkg:maven/commons-io/commons-io@2.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/commons-io/commons-io@2.6"
 		},
 		{
@@ -1260,6 +1414,7 @@
 			"version": "1.0.0.Final",
 			"purl": "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final"
 		},
 		{
@@ -1268,6 +1423,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final"
 		},
 		{
@@ -1276,6 +1432,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-core-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-core-deployment@2.0.2.Final"
 		},
 		{
@@ -1284,6 +1441,7 @@
 			"version": "2.1",
 			"purl": "pkg:maven/org.aesh/readline@2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.aesh/readline@2.1"
 		},
 		{
@@ -1292,6 +1450,7 @@
 			"version": "1.18",
 			"purl": "pkg:maven/org.fusesource.jansi/jansi@1.18",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.fusesource.jansi/jansi@1.18"
 		},
 		{
@@ -1300,6 +1459,7 @@
 			"version": "3.12.0",
 			"purl": "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.12.0"
 		},
 		{
@@ -1308,6 +1468,7 @@
 			"version": "1.0.9.Final",
 			"purl": "pkg:maven/io.quarkus.gizmo/gizmo@1.0.9.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.gizmo/gizmo@1.0.9.Final"
 		},
 		{
@@ -1316,6 +1477,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-util@9.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-util@9.1"
 		},
 		{
@@ -1324,6 +1486,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-tree@9.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-tree@9.1"
 		},
 		{
@@ -1332,6 +1495,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-analysis@9.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-analysis@9.1"
 		},
 		{
@@ -1340,6 +1504,7 @@
 			"version": "2.3.0.Final",
 			"purl": "pkg:maven/org.jboss/jandex@2.3.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss/jandex@2.3.0.Final"
 		},
 		{
@@ -1348,6 +1513,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-class-change-agent@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-class-change-agent@2.0.2.Final"
 		},
 		{
@@ -1356,6 +1522,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-core@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-core@2.0.2.Final"
 		},
 		{
@@ -1364,6 +1531,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-app-model@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-app-model@2.0.2.Final"
 		},
 		{
@@ -1372,6 +1540,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-maven-resolver@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-maven-resolver@2.0.2.Final"
 		},
 		{
@@ -1380,6 +1549,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-embedder@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-embedder@3.8.1"
 		},
 		{
@@ -1388,6 +1558,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-settings@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-settings@3.8.1"
 		},
 		{
@@ -1396,6 +1567,7 @@
 			"version": "3.3.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0"
 		},
 		{
@@ -1404,6 +1576,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-settings-builder@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-settings-builder@3.8.1"
 		},
 		{
@@ -1412,6 +1585,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-builder-support@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-builder-support@3.8.1"
 		},
 		{
@@ -1420,6 +1594,7 @@
 			"version": "1.25",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.25",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.25"
 		},
 		{
@@ -1428,6 +1603,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/org.sonatype.plexus/plexus-sec-dispatcher@1.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.sonatype.plexus/plexus-sec-dispatcher@1.4"
 		},
 		{
@@ -1436,6 +1612,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/org.sonatype.plexus/plexus-cipher@1.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.sonatype.plexus/plexus-cipher@1.4"
 		},
 		{
@@ -1444,6 +1621,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-core@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-core@3.8.1"
 		},
 		{
@@ -1452,6 +1630,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-model@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-model@3.8.1"
 		},
 		{
@@ -1460,6 +1639,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-repository-metadata@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-repository-metadata@3.8.1"
 		},
 		{
@@ -1468,6 +1648,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-artifact@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-artifact@3.8.1"
 		},
 		{
@@ -1476,6 +1657,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-plugin-api@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-plugin-api@3.8.1"
 		},
 		{
@@ -1484,6 +1666,7 @@
 			"version": "0.3.4",
 			"purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.4"
 		},
 		{
@@ -1492,6 +1675,7 @@
 			"version": "2.1.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0"
 		},
 		{
@@ -1500,6 +1684,7 @@
 			"version": "2.6.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0"
 		},
 		{
@@ -1508,6 +1693,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-model-builder@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-model-builder@3.8.1"
 		},
 		{
@@ -1516,6 +1702,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-resolver-provider@3.8.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-resolver-provider@3.8.1"
 		},
 		{
@@ -1524,6 +1711,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.6.2"
 		},
 		{
@@ -1532,6 +1720,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.6.2"
 		},
 		{
@@ -1540,6 +1729,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.6.2"
 		},
 		{
@@ -1548,6 +1738,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.6.2"
 		},
 		{
@@ -1556,6 +1747,7 @@
 			"version": "3.2.1",
 			"purl": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.2.1"
 		},
 		{
@@ -1564,6 +1756,7 @@
 			"version": "4.2.1",
 			"purl": "pkg:maven/com.google.inject/guice@4.2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.inject/guice@4.2.1"
 		},
 		{
@@ -1572,6 +1765,7 @@
 			"version": "1.0",
 			"purl": "pkg:maven/aopalliance/aopalliance@1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/aopalliance/aopalliance@1.0"
 		},
 		{
@@ -1580,6 +1774,7 @@
 			"version": "25.1-android",
 			"purl": "pkg:maven/com.google.guava/guava@25.1-android",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.guava/guava@25.1-android"
 		},
 		{
@@ -1588,6 +1783,7 @@
 			"version": "3.0.2",
 			"purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
 		},
 		{
@@ -1596,6 +1792,7 @@
 			"version": "2.0.0",
 			"purl": "pkg:maven/org.checkerframework/checker-compat-qual@2.0.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.checkerframework/checker-compat-qual@2.0.0"
 		},
 		{
@@ -1604,6 +1801,7 @@
 			"version": "1.1",
 			"purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.j2objc/j2objc-annotations@1.1"
 		},
 		{
@@ -1612,6 +1810,7 @@
 			"version": "1.14",
 			"purl": "pkg:maven/org.codehaus.mojo/animal-sniffer-annotations@1.14",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.codehaus.mojo/animal-sniffer-annotations@1.14"
 		},
 		{
@@ -1620,6 +1819,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/commons-cli/commons-cli@1.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/commons-cli/commons-cli@1.4"
 		},
 		{
@@ -1628,6 +1828,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.6.2"
 		},
 		{
@@ -1636,6 +1837,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.6.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.6.2"
 		},
 		{
@@ -1644,6 +1846,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-http@3.4.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http@3.4.3"
 		},
 		{
@@ -1652,6 +1855,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.4.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.4.3"
 		},
 		{
@@ -1660,6 +1864,7 @@
 			"version": "1.12.1",
 			"purl": "pkg:maven/org.jsoup/jsoup@1.12.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jsoup/jsoup@1.12.1"
 		},
 		{
@@ -1668,6 +1873,7 @@
 			"version": "4.5.13",
 			"purl": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13"
 		},
 		{
@@ -1676,6 +1882,7 @@
 			"version": "4.4.14",
 			"purl": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.14",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.14"
 		},
 		{
@@ -1684,6 +1891,7 @@
 			"version": "1.11",
 			"purl": "pkg:maven/commons-codec/commons-codec@1.11",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/commons-codec/commons-codec@1.11"
 		},
 		{
@@ -1692,6 +1900,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.4.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.4.3"
 		},
 		{
@@ -1700,6 +1909,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-file@3.4.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-file@3.4.3"
 		},
 		{
@@ -1708,6 +1918,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-gradle-resolver@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-gradle-resolver@2.0.2.Final"
 		},
 		{
@@ -1716,6 +1927,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-devtools-utilities@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-devtools-utilities@2.0.2.Final"
 		},
 		{
@@ -1724,6 +1936,7 @@
 			"version": "0.3.4",
 			"purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.4"
 		},
 		{
@@ -1732,6 +1945,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-builder@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-builder@2.0.2.Final"
 		},
 		{
@@ -1740,6 +1954,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-launcher@1.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-launcher@1.7.2"
 		},
 		{
@@ -1748,6 +1963,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit/junit-bom@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit/junit-bom@5.7.2"
 		},
 		{
@@ -1756,6 +1972,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.7.2"
 		},
 		{
@@ -1764,6 +1981,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.7.2"
 		},
 		{
@@ -1772,6 +1990,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.7.2"
 		},
 		{
@@ -1780,6 +1999,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.7.2"
 		},
 		{
@@ -1788,6 +2008,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.7.2"
 		},
 		{
@@ -1796,6 +2017,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2"
 		},
 		{
@@ -1804,6 +2026,7 @@
 			"version": "1.1.0",
 			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
 		},
 		{
@@ -1812,6 +2035,7 @@
 			"version": "1.2.0",
 			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
 		},
 		{
@@ -1820,6 +2044,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-narayana-jta-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-narayana-jta-deployment@2.0.2.Final"
 		},
 		{
@@ -1828,6 +2053,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-arc-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc-deployment@2.0.2.Final"
 		},
 		{
@@ -1836,6 +2062,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-spi@2.0.2.Final"
 		},
 		{
@@ -1844,6 +2071,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus.arc/arc-processor@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.arc/arc-processor@2.0.2.Final"
 		},
 		{
@@ -1852,6 +2080,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-mutiny-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny-deployment@2.0.2.Final"
 		},
 		{
@@ -1860,6 +2089,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation-deployment@2.0.2.Final"
 		},
 		{
@@ -1868,6 +2098,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal-deployment@2.0.2.Final"
 		},
 		{
@@ -1876,6 +2107,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-deployment@2.0.2.Final"
 		},
 		{
@@ -1884,6 +2116,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-deployment-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-deployment-spi@2.0.2.Final"
 		},
 		{
@@ -1892,6 +2125,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal-spi@2.0.2.Final"
 		},
 		{
@@ -1900,6 +2134,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-credentials-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials-deployment@2.0.2.Final"
 		},
 		{
@@ -1908,6 +2143,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-health-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-health-spi@2.0.2.Final"
 		},
 		{
@@ -1916,6 +2152,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-caffeine-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-caffeine-deployment@2.0.2.Final"
 		},
 		{
@@ -1924,6 +2161,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common-deployment@2.0.2.Final"
 		},
 		{
@@ -1932,6 +2170,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common@2.0.2.Final"
 		},
 		{
@@ -1940,6 +2179,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-common@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-common@2.0.2.Final"
 		},
 		{
@@ -1948,6 +2188,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-common-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-common-deployment@2.0.2.Final"
 		}
 	],

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_notations/expected_component_sbom.json
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_notations/expected_component_sbom.json
@@ -28,6 +28,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final"
 		},
 		{
@@ -36,6 +37,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final"
 		},
 		{
@@ -44,6 +46,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final"
 		},
 		{
@@ -52,6 +55,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final"
 		},
 		{
@@ -60,6 +64,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final"
 		},
 		{
@@ -68,6 +73,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final"
 		},
 		{
@@ -76,6 +82,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final"
 		},
 		{
@@ -84,6 +91,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
 		},
 		{
@@ -92,6 +100,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final"
 		},
 		{
@@ -100,6 +109,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final"
 		}
 	],

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_notations/expected_stack_sbom.json
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_notations/expected_stack_sbom.json
@@ -28,6 +28,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final"
 		},
 		{
@@ -36,6 +37,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final"
 		},
 		{
@@ -44,6 +46,7 @@
 			"version": "1.3.5",
 			"purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
 		},
 		{
@@ -52,6 +55,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
 		},
 		{
@@ -60,6 +64,7 @@
 			"version": "3.0.3",
 			"purl": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3"
 		},
 		{
@@ -68,6 +73,7 @@
 			"version": "1.2.5",
 			"purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
 		},
 		{
@@ -76,6 +82,7 @@
 			"version": "3.2.6",
 			"purl": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
 		},
 		{
@@ -84,6 +91,7 @@
 			"version": "1.3.3",
 			"purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
 		},
 		{
@@ -92,6 +100,7 @@
 			"version": "1.0",
 			"purl": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
 		},
 		{
@@ -100,6 +109,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final"
 		},
 		{
@@ -108,6 +118,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final"
 		},
 		{
@@ -116,6 +127,7 @@
 			"version": "2.12.0",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0"
 		},
 		{
@@ -124,6 +136,7 @@
 			"version": "2.12.0",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0"
 		},
 		{
@@ -132,6 +145,7 @@
 			"version": "2.0.1",
 			"purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1"
 		},
 		{
@@ -140,6 +154,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
 		},
 		{
@@ -148,6 +163,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1"
 		},
 		{
@@ -156,6 +172,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
 		},
 		{
@@ -164,6 +181,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
 		},
 		{
@@ -172,6 +190,7 @@
 			"version": "3.5.0.Final",
 			"purl": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final"
 		},
 		{
@@ -180,6 +199,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1"
 		},
 		{
@@ -188,6 +208,7 @@
 			"version": "9.3",
 			"purl": "pkg:maven/org.ow2.asm/asm@9.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.3"
 		},
 		{
@@ -196,6 +217,7 @@
 			"version": "2.12.0",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
 		},
 		{
@@ -204,6 +226,7 @@
 			"version": "1.0.10",
 			"purl": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
 		},
 		{
@@ -212,6 +235,7 @@
 			"version": "1.5.4.Final-format-001",
 			"purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
 		},
 		{
@@ -220,6 +244,7 @@
 			"version": "2.2.1.Final",
 			"purl": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final"
 		},
 		{
@@ -228,6 +253,7 @@
 			"version": "3.4.3.Final",
 			"purl": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
 		},
 		{
@@ -236,6 +262,7 @@
 			"version": "1.7.36",
 			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
 		},
 		{
@@ -244,6 +271,7 @@
 			"version": "1.2.0.Final",
 			"purl": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final"
 		},
 		{
@@ -252,6 +280,7 @@
 			"version": "22.3.0",
 			"purl": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0"
 		},
 		{
@@ -260,6 +289,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final"
 		},
 		{
@@ -268,6 +298,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
 		},
 		{
@@ -276,6 +307,7 @@
 			"version": "0.1.1",
 			"purl": "pkg:maven/io.github.crac/org-crac@0.1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.1"
 		},
 		{
@@ -284,6 +316,7 @@
 			"version": "0.0.9",
 			"purl": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
 		},
 		{
@@ -292,6 +325,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final"
 		},
 		{
@@ -300,6 +334,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final"
 		},
 		{
@@ -308,6 +343,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
 		},
 		{
@@ -316,6 +352,7 @@
 			"version": "1.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
 		},
 		{
@@ -324,6 +361,7 @@
 			"version": "1.0.3",
 			"purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
 		},
 		{
@@ -332,6 +370,7 @@
 			"version": "1.3",
 			"purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3"
 		},
 		{
@@ -340,6 +379,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource@2.13.5.Final"
 		},
 		{
@@ -348,6 +388,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-common@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-common@2.13.5.Final"
 		},
 		{
@@ -356,6 +397,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final"
 		},
 		{
@@ -364,6 +406,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final"
 		},
 		{
@@ -372,6 +415,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-transaction-annotations@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-transaction-annotations@2.13.5.Final"
 		},
 		{
@@ -380,6 +424,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final"
 		},
 		{
@@ -388,6 +433,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final"
 		},
 		{
@@ -396,6 +442,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
 		},
 		{
@@ -404,6 +451,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2"
 		},
 		{
@@ -412,6 +460,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2"
 		},
 		{
@@ -420,6 +469,7 @@
 			"version": "1.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
 		},
 		{
@@ -428,6 +478,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-jta@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-jta@1.2.2"
 		},
 		{
@@ -436,6 +487,7 @@
 			"version": "2.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-api@2.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-api@2.7.0"
 		},
 		{
@@ -444,6 +496,7 @@
 			"version": "2.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-mutiny@2.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-mutiny@2.7.0"
 		},
 		{
@@ -452,6 +505,7 @@
 			"version": "5.13.1.Alpha1",
 			"purl": "pkg:maven/org.jboss.narayana.jta/narayana-jta@5.13.1.Alpha1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.narayana.jta/narayana-jta@5.13.1.Alpha1"
 		},
 		{
@@ -460,6 +514,7 @@
 			"version": "7.6.1.Final",
 			"purl": "pkg:maven/org.jboss/jboss-transaction-spi@7.6.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss/jboss-transaction-spi@7.6.1.Final"
 		},
 		{
@@ -468,6 +523,7 @@
 			"version": "1.0.0.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@1.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@1.0.0.Final"
 		},
 		{
@@ -476,6 +532,7 @@
 			"version": "5.13.1.Alpha1",
 			"purl": "pkg:maven/org.jboss.narayana.jts/narayana-jts-integration@5.13.1.Alpha1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.narayana.jts/narayana-jts-integration@5.13.1.Alpha1"
 		},
 		{
@@ -484,6 +541,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-api@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-api@1.16"
 		},
 		{
@@ -492,6 +550,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-narayana@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-narayana@1.16"
 		},
 		{
@@ -500,6 +559,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-pool@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-pool@1.16"
 		},
 		{
@@ -508,6 +568,7 @@
 			"version": "5.6.14.Final",
 			"purl": "pkg:maven/org.hibernate/hibernate-core@5.6.14.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/hibernate-core@5.6.14.Final"
 		},
 		{
@@ -516,6 +577,7 @@
 			"version": "1.12.18",
 			"purl": "pkg:maven/net.bytebuddy/byte-buddy@1.12.18",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.12.18"
 		},
 		{
@@ -524,6 +586,7 @@
 			"version": "2.7.7",
 			"purl": "pkg:maven/antlr/antlr@2.7.7",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/antlr/antlr@2.7.7"
 		},
 		{
@@ -532,6 +595,7 @@
 			"version": "1.5.1",
 			"purl": "pkg:maven/com.fasterxml/classmate@1.5.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml/classmate@1.5.1"
 		},
 		{
@@ -540,6 +604,7 @@
 			"version": "5.1.2.Final",
 			"purl": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final"
 		},
 		{
@@ -548,6 +613,7 @@
 			"version": "5.6.14.Final",
 			"purl": "pkg:maven/org.hibernate/hibernate-graalvm@5.6.14.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/hibernate-graalvm@5.6.14.Final"
 		},
 		{
@@ -556,6 +622,7 @@
 			"version": "2.3.3-b02",
 			"purl": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.3-b02",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.3-b02"
 		},
 		{
@@ -564,6 +631,7 @@
 			"version": "2.3.3-b02",
 			"purl": "pkg:maven/org.glassfish.jaxb/txw2@2.3.3-b02",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.glassfish.jaxb/txw2@2.3.3-b02"
 		},
 		{
@@ -572,6 +640,7 @@
 			"version": "3.0.10",
 			"purl": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.10",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.10"
 		},
 		{
@@ -580,6 +649,7 @@
 			"version": "1.2.1",
 			"purl": "pkg:maven/com.sun.activation/jakarta.activation@1.2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.1"
 		},
 		{
@@ -588,6 +658,7 @@
 			"version": "2.0.0.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final"
 		},
 		{
@@ -596,6 +667,7 @@
 			"version": "2.2.3",
 			"purl": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3"
 		},
 		{
@@ -604,6 +676,7 @@
 			"version": "0.1.1",
 			"purl": "pkg:maven/org.hibernate/quarkus-local-cache@0.1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/quarkus-local-cache@0.1.1"
 		},
 		{
@@ -612,6 +685,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-caffeine@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-caffeine@2.13.5.Final"
 		},
 		{
@@ -620,6 +694,7 @@
 			"version": "2.9.3",
 			"purl": "pkg:maven/com.github.ben-manes.caffeine/caffeine@2.9.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.ben-manes.caffeine/caffeine@2.9.3"
 		},
 		{
@@ -628,6 +703,7 @@
 			"version": "2.10.0",
 			"purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.10.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.errorprone/error_prone_annotations@2.10.0"
 		},
 		{
@@ -636,6 +712,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final"
 		},
 		{
@@ -644,6 +721,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final"
 		},
 		{
@@ -652,6 +730,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final"
 		},
 		{
@@ -660,6 +739,7 @@
 			"version": "1.1.4.Final",
 			"purl": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
 		},
 		{
@@ -668,6 +748,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1"
 		},
 		{
@@ -676,6 +757,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-core@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.4"
 		},
 		{
@@ -684,6 +766,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-common@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-common@4.1.82.Final"
 		},
 		{
@@ -692,6 +775,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-buffer@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.82.Final"
 		},
 		{
@@ -700,6 +784,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-transport@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-transport@4.1.82.Final"
 		},
 		{
@@ -708,6 +793,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-resolver@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.82.Final"
 		},
 		{
@@ -716,6 +802,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-handler@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-handler@4.1.82.Final"
 		},
 		{
@@ -724,6 +811,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.82.Final"
 		},
 		{
@@ -732,6 +820,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec@4.1.82.Final"
 		},
 		{
@@ -740,6 +829,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final"
 		},
 		{
@@ -748,6 +838,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final"
 		},
 		{
@@ -756,6 +847,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-http@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.82.Final"
 		},
 		{
@@ -764,6 +856,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-http2@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.82.Final"
 		},
 		{
@@ -772,6 +865,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final"
 		},
 		{
@@ -780,6 +874,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final"
 		},
 		{
@@ -788,6 +883,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4"
 		},
 		{
@@ -796,6 +892,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final"
 		},
 		{
@@ -804,6 +901,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-web@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-web@4.3.4"
 		},
 		{
@@ -812,6 +910,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4"
 		},
 		{
@@ -820,6 +919,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4"
 		},
 		{
@@ -828,6 +928,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
 		},
 		{
@@ -836,6 +937,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final"
 		},
 		{
@@ -844,6 +946,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final"
 		},
 		{
@@ -852,6 +955,7 @@
 			"version": "1.7.1",
 			"purl": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
 		},
 		{
@@ -860,6 +964,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.82.Final"
 		},
 		{
@@ -868,6 +973,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final"
 		},
 		{
@@ -876,6 +982,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
 		},
 		{
@@ -884,6 +991,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0"
 		},
 		{
@@ -892,6 +1000,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
 		},
 		{
@@ -900,6 +1009,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4"
 		},
 		{
@@ -908,6 +1018,7 @@
 			"version": "5.5.0",
 			"purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
 		},
 		{
@@ -916,6 +1027,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0"
 		},
 		{
@@ -924,6 +1036,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0"
 		},
 		{
@@ -932,6 +1045,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0"
 		},
 		{
@@ -940,6 +1054,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0"
 		},
 		{
@@ -948,6 +1063,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
 		},
 		{
@@ -956,6 +1072,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4"
 		},
 		{
@@ -964,6 +1081,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.5.Final"
 		},
 		{
@@ -972,6 +1090,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.5.Final"
 		},
 		{
@@ -980,6 +1099,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final"
 		},
 		{
@@ -988,6 +1108,7 @@
 			"version": "2.0.1.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final"
 		},
 		{
@@ -996,6 +1117,7 @@
 			"version": "2.0.1.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final"
 		},
 		{
@@ -1004,6 +1126,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final"
 		},
 		{
@@ -1012,6 +1135,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
 		},
 		{
@@ -1020,6 +1144,7 @@
 			"version": "0.1.0",
 			"purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0"
 		},
 		{
@@ -1028,6 +1153,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final"
 		},
 		{
@@ -1036,6 +1162,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jackson@2.13.5.Final"
 		},
 		{
@@ -1044,6 +1171,7 @@
 			"version": "2.13.4.2",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.2"
 		},
 		{
@@ -1052,6 +1180,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.4"
 		},
 		{
@@ -1060,6 +1189,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.4"
 		},
 		{
@@ -1068,6 +1198,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.4"
 		},
 		{
@@ -1076,6 +1207,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.4"
 		},
 		{
@@ -1084,6 +1216,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-jackson2-provider@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-jackson2-provider@4.7.7.Final"
 		},
 		{
@@ -1092,6 +1225,7 @@
 			"version": "2.12.6",
 			"purl": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.12.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.12.6"
 		},
 		{
@@ -1100,6 +1234,7 @@
 			"version": "2.12.6",
 			"purl": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.12.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.12.6"
 		},
 		{
@@ -1108,6 +1243,7 @@
 			"version": "2.12.6",
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.12.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.12.6"
 		},
 		{
@@ -1116,6 +1252,7 @@
 			"version": "1.13",
 			"purl": "pkg:maven/com.github.java-json-tools/json-patch@1.13",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/json-patch@1.13"
 		},
 		{
@@ -1124,6 +1261,7 @@
 			"version": "1.2",
 			"purl": "pkg:maven/com.github.java-json-tools/msg-simple@1.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/msg-simple@1.2"
 		},
 		{
@@ -1132,6 +1270,7 @@
 			"version": "1.3",
 			"purl": "pkg:maven/com.github.java-json-tools/btf@1.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/btf@1.3"
 		},
 		{
@@ -1140,6 +1279,7 @@
 			"version": "2.0",
 			"purl": "pkg:maven/com.github.java-json-tools/jackson-coreutils@2.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/jackson-coreutils@2.0"
 		},
 		{
@@ -1148,6 +1288,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final"
 		},
 		{
@@ -1156,6 +1297,7 @@
 			"version": "42.5.0",
 			"purl": "pkg:maven/org.postgresql/postgresql@42.5.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.postgresql/postgresql@42.5.0"
 		},
 		{
@@ -1164,6 +1306,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final"
 		},
 		{
@@ -1172,6 +1315,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final"
 		},
 		{
@@ -1180,6 +1324,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image@2.13.5.Final"
 		},
 		{
@@ -1188,6 +1333,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final"
 		},
 		{
@@ -1196,6 +1342,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-core-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-core-deployment@2.0.2.Final"
 		},
 		{
@@ -1204,6 +1351,7 @@
 			"version": "2.1",
 			"purl": "pkg:maven/org.aesh/readline@2.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.aesh/readline@2.1"
 		},
 		{
@@ -1212,6 +1360,7 @@
 			"version": "1.18",
 			"purl": "pkg:maven/org.fusesource.jansi/jansi@1.18",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.fusesource.jansi/jansi@1.18"
 		},
 		{
@@ -1220,6 +1369,7 @@
 			"version": "3.12.0",
 			"purl": "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.12.0"
 		},
 		{
@@ -1228,6 +1378,7 @@
 			"version": "1.0.9.Final",
 			"purl": "pkg:maven/io.quarkus.gizmo/gizmo@1.0.9.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus.gizmo/gizmo@1.0.9.Final"
 		},
 		{
@@ -1236,6 +1387,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-util@9.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-util@9.1"
 		},
 		{
@@ -1244,6 +1396,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-tree@9.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-tree@9.1"
 		},
 		{
@@ -1252,6 +1405,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-analysis@9.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-analysis@9.1"
 		},
 		{
@@ -1260,6 +1414,7 @@
 			"version": "2.3.0.Final",
 			"purl": "pkg:maven/org.jboss/jandex@2.3.0.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.jboss/jandex@2.3.0.Final"
 		},
 		{
@@ -1268,6 +1423,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-class-change-agent@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-class-change-agent@2.0.2.Final"
 		},
 		{
@@ -1276,6 +1432,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-core@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-core@2.0.2.Final"
 		},
 		{
@@ -1284,6 +1441,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-app-model@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-app-model@2.0.2.Final"
 		},
 		{
@@ -1292,6 +1450,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-maven-resolver@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-maven-resolver@2.0.2.Final"
 		},
 		{
@@ -1300,6 +1459,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-embedder@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-embedder@3.8.1"
 		},
 		{
@@ -1308,6 +1468,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-settings@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-settings@3.8.1"
 		},
 		{
@@ -1316,6 +1477,7 @@
 			"version": "3.3.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0"
 		},
 		{
@@ -1324,6 +1486,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-settings-builder@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-settings-builder@3.8.1"
 		},
 		{
@@ -1332,6 +1495,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-builder-support@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-builder-support@3.8.1"
 		},
 		{
@@ -1340,6 +1504,7 @@
 			"version": "1.25",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.25",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.25"
 		},
 		{
@@ -1348,6 +1513,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/org.sonatype.plexus/plexus-sec-dispatcher@1.4",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.sonatype.plexus/plexus-sec-dispatcher@1.4"
 		},
 		{
@@ -1356,6 +1522,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/org.sonatype.plexus/plexus-cipher@1.4",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.sonatype.plexus/plexus-cipher@1.4"
 		},
 		{
@@ -1364,6 +1531,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-core@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-core@3.8.1"
 		},
 		{
@@ -1372,6 +1540,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-model@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-model@3.8.1"
 		},
 		{
@@ -1380,6 +1549,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-repository-metadata@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-repository-metadata@3.8.1"
 		},
 		{
@@ -1388,6 +1558,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-artifact@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-artifact@3.8.1"
 		},
 		{
@@ -1396,6 +1567,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-plugin-api@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-plugin-api@3.8.1"
 		},
 		{
@@ -1404,6 +1576,7 @@
 			"version": "0.3.4",
 			"purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.4",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.4"
 		},
 		{
@@ -1412,6 +1585,7 @@
 			"version": "2.1.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0"
 		},
 		{
@@ -1420,6 +1594,7 @@
 			"version": "2.6.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0"
 		},
 		{
@@ -1428,6 +1603,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-model-builder@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-model-builder@3.8.1"
 		},
 		{
@@ -1436,6 +1612,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-resolver-provider@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-resolver-provider@3.8.1"
 		},
 		{
@@ -1444,6 +1621,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.6.2"
 		},
 		{
@@ -1452,6 +1630,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.6.2"
 		},
 		{
@@ -1460,6 +1639,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.6.2"
 		},
 		{
@@ -1468,6 +1648,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.6.2"
 		},
 		{
@@ -1476,6 +1657,7 @@
 			"version": "3.2.1",
 			"purl": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.2.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.2.1"
 		},
 		{
@@ -1484,6 +1666,7 @@
 			"version": "2.6",
 			"purl": "pkg:maven/commons-io/commons-io@2.6",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/commons-io/commons-io@2.6"
 		},
 		{
@@ -1492,6 +1675,7 @@
 			"version": "4.2.1",
 			"purl": "pkg:maven/com.google.inject/guice@4.2.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/com.google.inject/guice@4.2.1"
 		},
 		{
@@ -1500,6 +1684,7 @@
 			"version": "1.0",
 			"purl": "pkg:maven/aopalliance/aopalliance@1.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/aopalliance/aopalliance@1.0"
 		},
 		{
@@ -1508,6 +1693,7 @@
 			"version": "25.1-android",
 			"purl": "pkg:maven/com.google.guava/guava@25.1-android",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/com.google.guava/guava@25.1-android"
 		},
 		{
@@ -1516,6 +1702,7 @@
 			"version": "3.0.2",
 			"purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
 		},
 		{
@@ -1524,6 +1711,7 @@
 			"version": "2.0.0",
 			"purl": "pkg:maven/org.checkerframework/checker-compat-qual@2.0.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.checkerframework/checker-compat-qual@2.0.0"
 		},
 		{
@@ -1532,6 +1720,7 @@
 			"version": "1.1",
 			"purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/com.google.j2objc/j2objc-annotations@1.1"
 		},
 		{
@@ -1540,6 +1729,7 @@
 			"version": "1.14",
 			"purl": "pkg:maven/org.codehaus.mojo/animal-sniffer-annotations@1.14",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.mojo/animal-sniffer-annotations@1.14"
 		},
 		{
@@ -1548,6 +1738,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/commons-cli/commons-cli@1.4",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/commons-cli/commons-cli@1.4"
 		},
 		{
@@ -1556,6 +1747,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.6.2"
 		},
 		{
@@ -1564,6 +1756,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.6.2"
 		},
 		{
@@ -1572,6 +1765,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-http@3.4.3",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http@3.4.3"
 		},
 		{
@@ -1580,6 +1774,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.4.3",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.4.3"
 		},
 		{
@@ -1588,6 +1783,7 @@
 			"version": "1.12.1",
 			"purl": "pkg:maven/org.jsoup/jsoup@1.12.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.jsoup/jsoup@1.12.1"
 		},
 		{
@@ -1596,6 +1792,7 @@
 			"version": "4.5.13",
 			"purl": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13"
 		},
 		{
@@ -1604,6 +1801,7 @@
 			"version": "4.4.14",
 			"purl": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.14",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.14"
 		},
 		{
@@ -1612,6 +1810,7 @@
 			"version": "1.11",
 			"purl": "pkg:maven/commons-codec/commons-codec@1.11",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/commons-codec/commons-codec@1.11"
 		},
 		{
@@ -1620,6 +1819,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.4.3",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.4.3"
 		},
 		{
@@ -1628,6 +1828,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-file@3.4.3",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-file@3.4.3"
 		},
 		{
@@ -1636,6 +1837,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-gradle-resolver@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-gradle-resolver@2.0.2.Final"
 		},
 		{
@@ -1644,6 +1846,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-devtools-utilities@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-devtools-utilities@2.0.2.Final"
 		},
 		{
@@ -1652,6 +1855,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-builder@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-builder@2.0.2.Final"
 		},
 		{
@@ -1660,6 +1864,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-launcher@1.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-launcher@1.7.2"
 		},
 		{
@@ -1668,6 +1873,7 @@
 			"version": "1.1.0",
 			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
 		},
 		{
@@ -1676,6 +1882,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.7.2"
 		},
 		{
@@ -1684,6 +1891,7 @@
 			"version": "1.2.0",
 			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
 		},
 		{
@@ -1692,6 +1900,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2"
 		},
 		{
@@ -1700,6 +1909,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.7.2"
 		},
 		{
@@ -1708,6 +1918,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.7.2"
 		},
 		{
@@ -1716,6 +1927,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.7.2"
 		},
 		{
@@ -1724,6 +1936,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-narayana-jta-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-narayana-jta-deployment@2.0.2.Final"
 		},
 		{
@@ -1732,6 +1945,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-arc-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc-deployment@2.0.2.Final"
 		},
 		{
@@ -1740,6 +1954,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-spi@2.0.2.Final"
 		},
 		{
@@ -1748,6 +1963,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus.arc/arc-processor@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus.arc/arc-processor@2.0.2.Final"
 		},
 		{
@@ -1756,6 +1972,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-mutiny-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny-deployment@2.0.2.Final"
 		},
 		{
@@ -1764,6 +1981,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation-deployment@2.0.2.Final"
 		},
 		{
@@ -1772,6 +1990,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal-deployment@2.0.2.Final"
 		},
 		{
@@ -1780,6 +1999,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-deployment@2.0.2.Final"
 		},
 		{
@@ -1788,6 +2008,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-deployment-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-deployment-spi@2.0.2.Final"
 		},
 		{
@@ -1796,6 +2017,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal-spi@2.0.2.Final"
 		},
 		{
@@ -1804,6 +2026,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-credentials-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials-deployment@2.0.2.Final"
 		},
 		{
@@ -1812,6 +2035,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-health-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-health-spi@2.0.2.Final"
 		},
 		{
@@ -1820,6 +2044,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-caffeine-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-caffeine-deployment@2.0.2.Final"
 		},
 		{
@@ -1828,6 +2053,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common-deployment@2.0.2.Final"
 		},
 		{
@@ -1836,6 +2062,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common@2.0.2.Final"
 		},
 		{
@@ -1844,6 +2071,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-common@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-common@2.0.2.Final"
 		},
 		{
@@ -1852,6 +2080,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-common-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-common-deployment@2.0.2.Final"
 		}
 	],

--- a/test/providers/tst_manifests/gradle/deps_with_no_ignore_common_paths/expected_component_sbom.json
+++ b/test/providers/tst_manifests/gradle/deps_with_no_ignore_common_paths/expected_component_sbom.json
@@ -28,6 +28,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final"
 		},
 		{
@@ -36,6 +37,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final"
 		},
 		{
@@ -44,6 +46,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final"
 		},
 		{
@@ -52,6 +55,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final"
 		},
 		{
@@ -60,6 +64,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final"
 		},
 		{
@@ -68,6 +73,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final"
 		},
 		{
@@ -76,6 +82,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final"
 		},
 		{
@@ -84,6 +91,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
 		},
 		{
@@ -92,6 +100,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final"
 		},
 		{
@@ -100,6 +109,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final"
 		}
 	],

--- a/test/providers/tst_manifests/gradle/deps_with_no_ignore_common_paths/expected_stack_sbom.json
+++ b/test/providers/tst_manifests/gradle/deps_with_no_ignore_common_paths/expected_stack_sbom.json
@@ -28,6 +28,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final"
 		},
 		{
@@ -36,6 +37,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final"
 		},
 		{
@@ -44,6 +46,7 @@
 			"version": "1.3.5",
 			"purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
 		},
 		{
@@ -52,6 +55,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
 		},
 		{
@@ -60,6 +64,7 @@
 			"version": "3.0.3",
 			"purl": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3"
 		},
 		{
@@ -68,6 +73,7 @@
 			"version": "1.2.5",
 			"purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
 		},
 		{
@@ -76,6 +82,7 @@
 			"version": "3.2.6",
 			"purl": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
 		},
 		{
@@ -84,6 +91,7 @@
 			"version": "1.3.3",
 			"purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
 		},
 		{
@@ -92,6 +100,7 @@
 			"version": "1.0",
 			"purl": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
 		},
 		{
@@ -100,6 +109,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final"
 		},
 		{
@@ -108,6 +118,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final"
 		},
 		{
@@ -116,6 +127,7 @@
 			"version": "2.12.0",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0"
 		},
 		{
@@ -124,6 +136,7 @@
 			"version": "2.12.0",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0"
 		},
 		{
@@ -132,6 +145,7 @@
 			"version": "2.0.1",
 			"purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1"
 		},
 		{
@@ -140,6 +154,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
 		},
 		{
@@ -148,6 +163,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1"
 		},
 		{
@@ -156,6 +172,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
 		},
 		{
@@ -164,6 +181,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
 		},
 		{
@@ -172,6 +190,7 @@
 			"version": "3.5.0.Final",
 			"purl": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final"
 		},
 		{
@@ -180,6 +199,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1"
 		},
 		{
@@ -188,6 +208,7 @@
 			"version": "9.3",
 			"purl": "pkg:maven/org.ow2.asm/asm@9.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.3"
 		},
 		{
@@ -196,6 +217,7 @@
 			"version": "2.12.0",
 			"purl": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
 		},
 		{
@@ -204,6 +226,7 @@
 			"version": "1.0.10",
 			"purl": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
 		},
 		{
@@ -212,6 +235,7 @@
 			"version": "1.5.4.Final-format-001",
 			"purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
 		},
 		{
@@ -220,6 +244,7 @@
 			"version": "2.2.1.Final",
 			"purl": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final"
 		},
 		{
@@ -228,6 +253,7 @@
 			"version": "3.4.3.Final",
 			"purl": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
 		},
 		{
@@ -236,6 +262,7 @@
 			"version": "1.7.36",
 			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
 		},
 		{
@@ -244,6 +271,7 @@
 			"version": "1.2.0.Final",
 			"purl": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final"
 		},
 		{
@@ -252,6 +280,7 @@
 			"version": "22.3.0",
 			"purl": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0"
 		},
 		{
@@ -260,6 +289,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final"
 		},
 		{
@@ -268,6 +298,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
 		},
 		{
@@ -276,6 +307,7 @@
 			"version": "0.1.1",
 			"purl": "pkg:maven/io.github.crac/org-crac@0.1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.1"
 		},
 		{
@@ -284,6 +316,7 @@
 			"version": "0.0.9",
 			"purl": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
 		},
 		{
@@ -292,6 +325,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal@2.13.5.Final"
 		},
 		{
@@ -300,6 +334,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final"
 		},
 		{
@@ -308,6 +343,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
 		},
 		{
@@ -316,6 +352,7 @@
 			"version": "1.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
 		},
 		{
@@ -324,6 +361,7 @@
 			"version": "1.0.3",
 			"purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
 		},
 		{
@@ -332,6 +370,7 @@
 			"version": "1.3",
 			"purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3"
 		},
 		{
@@ -340,6 +379,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource@2.13.5.Final"
 		},
 		{
@@ -348,6 +388,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-common@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-common@2.13.5.Final"
 		},
 		{
@@ -356,6 +397,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final"
 		},
 		{
@@ -364,6 +406,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final"
 		},
 		{
@@ -372,6 +415,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-transaction-annotations@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-transaction-annotations@2.13.5.Final"
 		},
 		{
@@ -380,6 +424,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final"
 		},
 		{
@@ -388,6 +433,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final"
 		},
 		{
@@ -396,6 +442,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
 		},
 		{
@@ -404,6 +451,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2"
 		},
 		{
@@ -412,6 +460,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2"
 		},
 		{
@@ -420,6 +469,7 @@
 			"version": "1.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
 		},
 		{
@@ -428,6 +478,7 @@
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-jta@1.2.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-jta@1.2.2"
 		},
 		{
@@ -436,6 +487,7 @@
 			"version": "2.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-api@2.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-api@2.7.0"
 		},
 		{
@@ -444,6 +496,7 @@
 			"version": "2.7.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-mutiny@2.7.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-reactive-converter-mutiny@2.7.0"
 		},
 		{
@@ -452,6 +505,7 @@
 			"version": "5.13.1.Alpha1",
 			"purl": "pkg:maven/org.jboss.narayana.jta/narayana-jta@5.13.1.Alpha1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.narayana.jta/narayana-jta@5.13.1.Alpha1"
 		},
 		{
@@ -460,6 +514,7 @@
 			"version": "7.6.1.Final",
 			"purl": "pkg:maven/org.jboss/jboss-transaction-spi@7.6.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss/jboss-transaction-spi@7.6.1.Final"
 		},
 		{
@@ -468,6 +523,7 @@
 			"version": "1.0.0.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@1.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@1.0.0.Final"
 		},
 		{
@@ -476,6 +532,7 @@
 			"version": "5.13.1.Alpha1",
 			"purl": "pkg:maven/org.jboss.narayana.jts/narayana-jts-integration@5.13.1.Alpha1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.narayana.jts/narayana-jts-integration@5.13.1.Alpha1"
 		},
 		{
@@ -484,6 +541,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-api@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-api@1.16"
 		},
 		{
@@ -492,6 +550,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-narayana@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-narayana@1.16"
 		},
 		{
@@ -500,6 +559,7 @@
 			"version": "1.16",
 			"purl": "pkg:maven/io.agroal/agroal-pool@1.16",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.agroal/agroal-pool@1.16"
 		},
 		{
@@ -508,6 +568,7 @@
 			"version": "5.6.14.Final",
 			"purl": "pkg:maven/org.hibernate/hibernate-core@5.6.14.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/hibernate-core@5.6.14.Final"
 		},
 		{
@@ -516,6 +577,7 @@
 			"version": "1.12.18",
 			"purl": "pkg:maven/net.bytebuddy/byte-buddy@1.12.18",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.12.18"
 		},
 		{
@@ -524,6 +586,7 @@
 			"version": "2.7.7",
 			"purl": "pkg:maven/antlr/antlr@2.7.7",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/antlr/antlr@2.7.7"
 		},
 		{
@@ -532,6 +595,7 @@
 			"version": "1.5.1",
 			"purl": "pkg:maven/com.fasterxml/classmate@1.5.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml/classmate@1.5.1"
 		},
 		{
@@ -540,6 +604,7 @@
 			"version": "5.1.2.Final",
 			"purl": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final"
 		},
 		{
@@ -548,6 +613,7 @@
 			"version": "5.6.14.Final",
 			"purl": "pkg:maven/org.hibernate/hibernate-graalvm@5.6.14.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/hibernate-graalvm@5.6.14.Final"
 		},
 		{
@@ -556,6 +622,7 @@
 			"version": "2.3.3-b02",
 			"purl": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.3-b02",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.3-b02"
 		},
 		{
@@ -564,6 +631,7 @@
 			"version": "2.3.3-b02",
 			"purl": "pkg:maven/org.glassfish.jaxb/txw2@2.3.3-b02",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.glassfish.jaxb/txw2@2.3.3-b02"
 		},
 		{
@@ -572,6 +640,7 @@
 			"version": "3.0.10",
 			"purl": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.10",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.10"
 		},
 		{
@@ -580,6 +649,7 @@
 			"version": "1.2.1",
 			"purl": "pkg:maven/com.sun.activation/jakarta.activation@1.2.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.1"
 		},
 		{
@@ -588,6 +658,7 @@
 			"version": "2.0.0.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final"
 		},
 		{
@@ -596,6 +667,7 @@
 			"version": "2.2.3",
 			"purl": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3"
 		},
 		{
@@ -604,6 +676,7 @@
 			"version": "0.1.1",
 			"purl": "pkg:maven/org.hibernate/quarkus-local-cache@0.1.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.hibernate/quarkus-local-cache@0.1.1"
 		},
 		{
@@ -612,6 +685,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-caffeine@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-caffeine@2.13.5.Final"
 		},
 		{
@@ -620,6 +694,7 @@
 			"version": "2.9.3",
 			"purl": "pkg:maven/com.github.ben-manes.caffeine/caffeine@2.9.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.ben-manes.caffeine/caffeine@2.9.3"
 		},
 		{
@@ -628,6 +703,7 @@
 			"version": "2.10.0",
 			"purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.10.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.google.errorprone/error_prone_annotations@2.10.0"
 		},
 		{
@@ -636,6 +712,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.13.5.Final"
 		},
 		{
@@ -644,6 +721,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final"
 		},
 		{
@@ -652,6 +730,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final"
 		},
 		{
@@ -660,6 +739,7 @@
 			"version": "1.1.4.Final",
 			"purl": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
 		},
 		{
@@ -668,6 +748,7 @@
 			"version": "1.13.1",
 			"purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1"
 		},
 		{
@@ -676,6 +757,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-core@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.4"
 		},
 		{
@@ -684,6 +766,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-common@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-common@4.1.82.Final"
 		},
 		{
@@ -692,6 +775,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-buffer@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.82.Final"
 		},
 		{
@@ -700,6 +784,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-transport@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-transport@4.1.82.Final"
 		},
 		{
@@ -708,6 +793,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-resolver@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.82.Final"
 		},
 		{
@@ -716,6 +802,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-handler@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-handler@4.1.82.Final"
 		},
 		{
@@ -724,6 +811,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.82.Final"
 		},
 		{
@@ -732,6 +820,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec@4.1.82.Final"
 		},
 		{
@@ -740,6 +829,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final"
 		},
 		{
@@ -748,6 +838,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final"
 		},
 		{
@@ -756,6 +847,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-http@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.82.Final"
 		},
 		{
@@ -764,6 +856,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-http2@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.82.Final"
 		},
 		{
@@ -772,6 +865,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final"
 		},
 		{
@@ -780,6 +874,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final"
 		},
 		{
@@ -788,6 +883,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4"
 		},
 		{
@@ -796,6 +892,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final"
 		},
 		{
@@ -804,6 +901,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-web@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-web@4.3.4"
 		},
 		{
@@ -812,6 +910,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4"
 		},
 		{
@@ -820,6 +919,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4"
 		},
 		{
@@ -828,6 +928,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
 		},
 		{
@@ -836,6 +937,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final"
 		},
 		{
@@ -844,6 +946,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final"
 		},
 		{
@@ -852,6 +955,7 @@
 			"version": "1.7.1",
 			"purl": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
 		},
 		{
@@ -860,6 +964,7 @@
 			"version": "4.1.82.Final",
 			"purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.82.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.82.Final"
 		},
 		{
@@ -868,6 +973,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final"
 		},
 		{
@@ -876,6 +982,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
 		},
 		{
@@ -884,6 +991,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0"
 		},
 		{
@@ -892,6 +1000,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
 		},
 		{
@@ -900,6 +1009,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4"
 		},
 		{
@@ -908,6 +1018,7 @@
 			"version": "5.5.0",
 			"purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
 		},
 		{
@@ -916,6 +1027,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0"
 		},
 		{
@@ -924,6 +1036,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0"
 		},
 		{
@@ -932,6 +1045,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0"
 		},
 		{
@@ -940,6 +1054,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0"
 		},
 		{
@@ -948,6 +1063,7 @@
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
 		},
 		{
@@ -956,6 +1072,7 @@
 			"version": "4.3.4",
 			"purl": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4"
 		},
 		{
@@ -964,6 +1081,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.5.Final"
 		},
 		{
@@ -972,6 +1090,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.5.Final"
 		},
 		{
@@ -980,6 +1099,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final"
 		},
 		{
@@ -988,6 +1108,7 @@
 			"version": "2.0.1.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final"
 		},
 		{
@@ -996,6 +1117,7 @@
 			"version": "2.0.1.Final",
 			"purl": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final"
 		},
 		{
@@ -1004,6 +1126,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final"
 		},
 		{
@@ -1012,6 +1135,7 @@
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
 		},
 		{
@@ -1020,6 +1144,7 @@
 			"version": "0.1.0",
 			"purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0"
 		},
 		{
@@ -1028,6 +1153,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-jackson@2.13.5.Final"
 		},
 		{
@@ -1036,6 +1162,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jackson@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jackson@2.13.5.Final"
 		},
 		{
@@ -1044,6 +1171,7 @@
 			"version": "2.13.4.2",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.2"
 		},
 		{
@@ -1052,6 +1180,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.4"
 		},
 		{
@@ -1060,6 +1189,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.4"
 		},
 		{
@@ -1068,6 +1198,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.4"
 		},
 		{
@@ -1076,6 +1207,7 @@
 			"version": "2.13.4",
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.4",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.4"
 		},
 		{
@@ -1084,6 +1216,7 @@
 			"version": "4.7.7.Final",
 			"purl": "pkg:maven/org.jboss.resteasy/resteasy-jackson2-provider@4.7.7.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-jackson2-provider@4.7.7.Final"
 		},
 		{
@@ -1092,6 +1225,7 @@
 			"version": "2.12.6",
 			"purl": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.12.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.12.6"
 		},
 		{
@@ -1100,6 +1234,7 @@
 			"version": "2.12.6",
 			"purl": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.12.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.12.6"
 		},
 		{
@@ -1108,6 +1243,7 @@
 			"version": "2.12.6",
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.12.6",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.12.6"
 		},
 		{
@@ -1116,6 +1252,7 @@
 			"version": "1.13",
 			"purl": "pkg:maven/com.github.java-json-tools/json-patch@1.13",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/json-patch@1.13"
 		},
 		{
@@ -1124,6 +1261,7 @@
 			"version": "1.2",
 			"purl": "pkg:maven/com.github.java-json-tools/msg-simple@1.2",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/msg-simple@1.2"
 		},
 		{
@@ -1132,6 +1270,7 @@
 			"version": "1.3",
 			"purl": "pkg:maven/com.github.java-json-tools/btf@1.3",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/btf@1.3"
 		},
 		{
@@ -1140,6 +1279,7 @@
 			"version": "2.0",
 			"purl": "pkg:maven/com.github.java-json-tools/jackson-coreutils@2.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/com.github.java-json-tools/jackson-coreutils@2.0"
 		},
 		{
@@ -1148,6 +1288,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final"
 		},
 		{
@@ -1156,6 +1297,7 @@
 			"version": "42.5.0",
 			"purl": "pkg:maven/org.postgresql/postgresql@42.5.0",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/org.postgresql/postgresql@42.5.0"
 		},
 		{
@@ -1164,6 +1306,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding@2.13.5.Final"
 		},
 		{
@@ -1172,6 +1315,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image-docker@2.13.5.Final"
 		},
 		{
@@ -1180,6 +1324,7 @@
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-container-image@2.13.5.Final",
 			"type": "library",
+			"scope": "required",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-container-image@2.13.5.Final"
 		},
 		{
@@ -1188,6 +1333,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm-deployment@2.0.2.Final"
 		},
 		{
@@ -1196,6 +1342,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-core-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-core-deployment@2.0.2.Final"
 		},
 		{
@@ -1204,6 +1351,7 @@
 			"version": "2.1",
 			"purl": "pkg:maven/org.aesh/readline@2.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.aesh/readline@2.1"
 		},
 		{
@@ -1212,6 +1360,7 @@
 			"version": "1.18",
 			"purl": "pkg:maven/org.fusesource.jansi/jansi@1.18",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.fusesource.jansi/jansi@1.18"
 		},
 		{
@@ -1220,6 +1369,7 @@
 			"version": "3.12.0",
 			"purl": "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.12.0"
 		},
 		{
@@ -1228,6 +1378,7 @@
 			"version": "1.0.9.Final",
 			"purl": "pkg:maven/io.quarkus.gizmo/gizmo@1.0.9.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus.gizmo/gizmo@1.0.9.Final"
 		},
 		{
@@ -1236,6 +1387,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-util@9.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-util@9.1"
 		},
 		{
@@ -1244,6 +1396,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-tree@9.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-tree@9.1"
 		},
 		{
@@ -1252,6 +1405,7 @@
 			"version": "9.1",
 			"purl": "pkg:maven/org.ow2.asm/asm-analysis@9.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.ow2.asm/asm-analysis@9.1"
 		},
 		{
@@ -1260,6 +1414,7 @@
 			"version": "2.3.0.Final",
 			"purl": "pkg:maven/org.jboss/jandex@2.3.0.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.jboss/jandex@2.3.0.Final"
 		},
 		{
@@ -1268,6 +1423,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-class-change-agent@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-class-change-agent@2.0.2.Final"
 		},
 		{
@@ -1276,6 +1432,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-core@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-core@2.0.2.Final"
 		},
 		{
@@ -1284,6 +1441,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-app-model@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-app-model@2.0.2.Final"
 		},
 		{
@@ -1292,6 +1450,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-maven-resolver@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-maven-resolver@2.0.2.Final"
 		},
 		{
@@ -1300,6 +1459,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-embedder@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-embedder@3.8.1"
 		},
 		{
@@ -1308,6 +1468,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-settings@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-settings@3.8.1"
 		},
 		{
@@ -1316,6 +1477,7 @@
 			"version": "3.3.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0"
 		},
 		{
@@ -1324,6 +1486,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-settings-builder@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-settings-builder@3.8.1"
 		},
 		{
@@ -1332,6 +1495,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-builder-support@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-builder-support@3.8.1"
 		},
 		{
@@ -1340,6 +1504,7 @@
 			"version": "1.25",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.25",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.25"
 		},
 		{
@@ -1348,6 +1513,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/org.sonatype.plexus/plexus-sec-dispatcher@1.4",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.sonatype.plexus/plexus-sec-dispatcher@1.4"
 		},
 		{
@@ -1356,6 +1522,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/org.sonatype.plexus/plexus-cipher@1.4",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.sonatype.plexus/plexus-cipher@1.4"
 		},
 		{
@@ -1364,6 +1531,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-core@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-core@3.8.1"
 		},
 		{
@@ -1372,6 +1540,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-model@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-model@3.8.1"
 		},
 		{
@@ -1380,6 +1549,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-repository-metadata@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-repository-metadata@3.8.1"
 		},
 		{
@@ -1388,6 +1558,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-artifact@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-artifact@3.8.1"
 		},
 		{
@@ -1396,6 +1567,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-plugin-api@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-plugin-api@3.8.1"
 		},
 		{
@@ -1404,6 +1576,7 @@
 			"version": "0.3.4",
 			"purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.4",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.4"
 		},
 		{
@@ -1412,6 +1585,7 @@
 			"version": "2.1.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0"
 		},
 		{
@@ -1420,6 +1594,7 @@
 			"version": "2.6.0",
 			"purl": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0"
 		},
 		{
@@ -1428,6 +1603,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-model-builder@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-model-builder@3.8.1"
 		},
 		{
@@ -1436,6 +1612,7 @@
 			"version": "3.8.1",
 			"purl": "pkg:maven/org.apache.maven/maven-resolver-provider@3.8.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven/maven-resolver-provider@3.8.1"
 		},
 		{
@@ -1444,6 +1621,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.6.2"
 		},
 		{
@@ -1452,6 +1630,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.6.2"
 		},
 		{
@@ -1460,6 +1639,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.6.2"
 		},
 		{
@@ -1468,6 +1648,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.6.2"
 		},
 		{
@@ -1476,6 +1657,7 @@
 			"version": "3.2.1",
 			"purl": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.2.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.2.1"
 		},
 		{
@@ -1484,6 +1666,7 @@
 			"version": "2.6",
 			"purl": "pkg:maven/commons-io/commons-io@2.6",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/commons-io/commons-io@2.6"
 		},
 		{
@@ -1492,6 +1675,7 @@
 			"version": "4.2.1",
 			"purl": "pkg:maven/com.google.inject/guice@4.2.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/com.google.inject/guice@4.2.1"
 		},
 		{
@@ -1500,6 +1684,7 @@
 			"version": "1.0",
 			"purl": "pkg:maven/aopalliance/aopalliance@1.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/aopalliance/aopalliance@1.0"
 		},
 		{
@@ -1508,6 +1693,7 @@
 			"version": "25.1-android",
 			"purl": "pkg:maven/com.google.guava/guava@25.1-android",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/com.google.guava/guava@25.1-android"
 		},
 		{
@@ -1516,6 +1702,7 @@
 			"version": "3.0.2",
 			"purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
 		},
 		{
@@ -1524,6 +1711,7 @@
 			"version": "2.0.0",
 			"purl": "pkg:maven/org.checkerframework/checker-compat-qual@2.0.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.checkerframework/checker-compat-qual@2.0.0"
 		},
 		{
@@ -1532,6 +1720,7 @@
 			"version": "1.1",
 			"purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/com.google.j2objc/j2objc-annotations@1.1"
 		},
 		{
@@ -1540,6 +1729,7 @@
 			"version": "1.14",
 			"purl": "pkg:maven/org.codehaus.mojo/animal-sniffer-annotations@1.14",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.codehaus.mojo/animal-sniffer-annotations@1.14"
 		},
 		{
@@ -1548,6 +1738,7 @@
 			"version": "1.4",
 			"purl": "pkg:maven/commons-cli/commons-cli@1.4",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/commons-cli/commons-cli@1.4"
 		},
 		{
@@ -1556,6 +1747,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.6.2"
 		},
 		{
@@ -1564,6 +1756,7 @@
 			"version": "1.6.2",
 			"purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.6.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.6.2"
 		},
 		{
@@ -1572,6 +1765,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-http@3.4.3",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http@3.4.3"
 		},
 		{
@@ -1580,6 +1774,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.4.3",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.4.3"
 		},
 		{
@@ -1588,6 +1783,7 @@
 			"version": "1.12.1",
 			"purl": "pkg:maven/org.jsoup/jsoup@1.12.1",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.jsoup/jsoup@1.12.1"
 		},
 		{
@@ -1596,6 +1792,7 @@
 			"version": "4.5.13",
 			"purl": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13"
 		},
 		{
@@ -1604,6 +1801,7 @@
 			"version": "4.4.14",
 			"purl": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.14",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.14"
 		},
 		{
@@ -1612,6 +1810,7 @@
 			"version": "1.11",
 			"purl": "pkg:maven/commons-codec/commons-codec@1.11",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/commons-codec/commons-codec@1.11"
 		},
 		{
@@ -1620,6 +1819,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.4.3",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.4.3"
 		},
 		{
@@ -1628,6 +1828,7 @@
 			"version": "3.4.3",
 			"purl": "pkg:maven/org.apache.maven.wagon/wagon-file@3.4.3",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-file@3.4.3"
 		},
 		{
@@ -1636,6 +1837,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-gradle-resolver@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-gradle-resolver@2.0.2.Final"
 		},
 		{
@@ -1644,6 +1846,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-devtools-utilities@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-devtools-utilities@2.0.2.Final"
 		},
 		{
@@ -1652,6 +1855,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-builder@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-builder@2.0.2.Final"
 		},
 		{
@@ -1660,6 +1864,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-launcher@1.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-launcher@1.7.2"
 		},
 		{
@@ -1668,6 +1873,7 @@
 			"version": "1.1.0",
 			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
 		},
 		{
@@ -1676,6 +1882,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.7.2"
 		},
 		{
@@ -1684,6 +1891,7 @@
 			"version": "1.2.0",
 			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
 		},
 		{
@@ -1692,6 +1900,7 @@
 			"version": "1.7.2",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2"
 		},
 		{
@@ -1700,6 +1909,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.7.2"
 		},
 		{
@@ -1708,6 +1918,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.7.2"
 		},
 		{
@@ -1716,6 +1927,7 @@
 			"version": "5.7.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.7.2",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.7.2"
 		},
 		{
@@ -1724,6 +1936,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-narayana-jta-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-narayana-jta-deployment@2.0.2.Final"
 		},
 		{
@@ -1732,6 +1945,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-arc-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc-deployment@2.0.2.Final"
 		},
 		{
@@ -1740,6 +1954,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-spi@2.0.2.Final"
 		},
 		{
@@ -1748,6 +1963,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus.arc/arc-processor@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus.arc/arc-processor@2.0.2.Final"
 		},
 		{
@@ -1756,6 +1972,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-mutiny-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny-deployment@2.0.2.Final"
 		},
 		{
@@ -1764,6 +1981,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation-deployment@2.0.2.Final"
 		},
 		{
@@ -1772,6 +1990,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal-deployment@2.0.2.Final"
 		},
 		{
@@ -1780,6 +1999,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-deployment@2.0.2.Final"
 		},
 		{
@@ -1788,6 +2008,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-datasource-deployment-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-datasource-deployment-spi@2.0.2.Final"
 		},
 		{
@@ -1796,6 +2017,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-agroal-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-agroal-spi@2.0.2.Final"
 		},
 		{
@@ -1804,6 +2026,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-credentials-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials-deployment@2.0.2.Final"
 		},
 		{
@@ -1812,6 +2035,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-health-spi@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-health-spi@2.0.2.Final"
 		},
 		{
@@ -1820,6 +2044,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-caffeine-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-caffeine-deployment@2.0.2.Final"
 		},
 		{
@@ -1828,6 +2053,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common-deployment@2.0.2.Final"
 		},
 		{
@@ -1836,6 +2062,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-hibernate-common@2.0.2.Final"
 		},
 		{
@@ -1844,6 +2071,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-common@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-common@2.0.2.Final"
 		},
 		{
@@ -1852,6 +2080,7 @@
 			"version": "2.0.2.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-panache-common-deployment@2.0.2.Final",
 			"type": "library",
+			"scope": "optional",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-panache-common-deployment@2.0.2.Final"
 		}
 	],

--- a/test/providers/tst_manifests/js-common/package_json_deps_without_exhortignore_object/component_expected_sbom.json
+++ b/test/providers/tst_manifests/js-common/package_json_deps_without_exhortignore_object/component_expected_sbom.json
@@ -64,6 +64,13 @@
 			"bom-ref": "pkg:npm/express@4.18.2"
 		},
 		{
+			"name": "jsdom",
+			"version": "19.0.0",
+			"purl": "pkg:npm/jsdom@19.0.0",
+			"type": "library",
+			"bom-ref": "pkg:npm/jsdom@19.0.0"
+		},
+		{
 			"name": "jsonwebtoken",
 			"version": "8.5.1",
 			"purl": "pkg:npm/jsonwebtoken@8.5.1",
@@ -132,6 +139,10 @@
 			"ref": "pkg:npm/express@4.18.2",
 			"dependsOn": []
 		},
+    {
+      "ref": "pkg:npm/jsdom@19.0.0",
+      "dependsOn": []
+    },
 		{
 			"ref": "pkg:npm/jsonwebtoken@8.5.1",
 			"dependsOn": []

--- a/test/providers/tst_manifests/yarn-berry/package_json_deps_without_exhortignore_object/stack_expected_sbom.json
+++ b/test/providers/tst_manifests/yarn-berry/package_json_deps_without_exhortignore_object/stack_expected_sbom.json
@@ -917,10 +917,10 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/fsevents%40patch%3Afsevents@2.3.3",
+      "bom-ref" : "pkg:npm/fsevents%40patch:fsevents@2.3.3",
       "name" : "fsevents@patch:fsevents",
       "version" : "2.3.3",
-      "purl" : "pkg:npm/fsevents%40patch%3Afsevents@2.3.3"
+      "purl" : "pkg:npm/fsevents%40patch:fsevents@2.3.3"
     },
     {
       "type" : "library",
@@ -2581,7 +2581,7 @@
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/fsevents%40patch%3Afsevents@2.3.3",
+      "ref" : "pkg:npm/fsevents%40patch:fsevents@2.3.3",
       "dependsOn" : [
         "pkg:npm/node-gyp@11.2.0"
       ]

--- a/test/providers/tst_manifests/yarn-classic/package_json_deps_with_exhortignore_object/stack_expected_sbom.json
+++ b/test/providers/tst_manifests/yarn-classic/package_json_deps_with_exhortignore_object/stack_expected_sbom.json
@@ -22,2028 +22,2028 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/joi@%4017.1.1",
+      "bom-ref" : "pkg:npm/%40hapi/joi@17.1.1",
       "group" : "@hapi",
       "name" : "joi",
-      "version" : "@17.1.1",
-      "purl" : "pkg:npm/%40hapi/joi@%4017.1.1"
+      "version" : "17.1.1",
+      "purl" : "pkg:npm/%40hapi/joi@17.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/backend@%400.0.0",
+      "bom-ref" : "pkg:npm/backend@0.0.0",
       "name" : "backend",
-      "version" : "@0.0.0",
-      "purl" : "pkg:npm/backend@%400.0.0"
+      "version" : "0.0.0",
+      "purl" : "pkg:npm/backend@0.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bcryptjs@%402.4.3",
+      "bom-ref" : "pkg:npm/bcryptjs@2.4.3",
       "name" : "bcryptjs",
-      "version" : "@2.4.3",
-      "purl" : "pkg:npm/bcryptjs@%402.4.3"
+      "version" : "2.4.3",
+      "purl" : "pkg:npm/bcryptjs@2.4.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/dotenv@%408.6.0",
+      "bom-ref" : "pkg:npm/dotenv@8.6.0",
       "name" : "dotenv",
-      "version" : "@8.6.0",
-      "purl" : "pkg:npm/dotenv@%408.6.0"
+      "version" : "8.6.0",
+      "purl" : "pkg:npm/dotenv@8.6.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/express@%404.21.2",
+      "bom-ref" : "pkg:npm/express@4.21.2",
       "name" : "express",
-      "version" : "@4.21.2",
-      "purl" : "pkg:npm/express@%404.21.2"
+      "version" : "4.21.2",
+      "purl" : "pkg:npm/express@4.21.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mongoose@%405.13.23",
+      "bom-ref" : "pkg:npm/mongoose@5.13.23",
       "name" : "mongoose",
-      "version" : "@5.13.23",
-      "purl" : "pkg:npm/mongoose@%405.13.23"
+      "version" : "5.13.23",
+      "purl" : "pkg:npm/mongoose@5.13.23"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/nodemon@%402.0.22",
+      "bom-ref" : "pkg:npm/nodemon@2.0.22",
       "name" : "nodemon",
-      "version" : "@2.0.22",
-      "purl" : "pkg:npm/nodemon@%402.0.22"
+      "version" : "2.0.22",
+      "purl" : "pkg:npm/nodemon@2.0.22"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/axios@%400.19.2",
+      "bom-ref" : "pkg:npm/axios@0.19.2",
       "name" : "axios",
-      "version" : "@0.19.2",
-      "purl" : "pkg:npm/axios@%400.19.2"
+      "version" : "0.19.2",
+      "purl" : "pkg:npm/axios@0.19.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/debug@%402.6.9",
+      "bom-ref" : "pkg:npm/debug@2.6.9",
       "name" : "debug",
-      "version" : "@2.6.9",
-      "purl" : "pkg:npm/debug@%402.6.9"
+      "version" : "2.6.9",
+      "purl" : "pkg:npm/debug@2.6.9"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ms@%402.1.3",
+      "bom-ref" : "pkg:npm/ms@2.1.3",
       "name" : "ms",
-      "version" : "@2.1.3",
-      "purl" : "pkg:npm/ms@%402.1.3"
+      "version" : "2.1.3",
+      "purl" : "pkg:npm/ms@2.1.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ms@%402.0.0",
+      "bom-ref" : "pkg:npm/ms@2.0.0",
       "name" : "ms",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/ms@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/ms@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/address@%404.1.0",
+      "bom-ref" : "pkg:npm/%40hapi/address@4.1.0",
       "group" : "@hapi",
       "name" : "address",
-      "version" : "@4.1.0",
-      "purl" : "pkg:npm/%40hapi/address@%404.1.0"
+      "version" : "4.1.0",
+      "purl" : "pkg:npm/%40hapi/address@4.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/formula@%402.0.0",
+      "bom-ref" : "pkg:npm/%40hapi/formula@2.0.0",
       "group" : "@hapi",
       "name" : "formula",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/%40hapi/formula@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/%40hapi/formula@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/hoek@%409.3.0",
+      "bom-ref" : "pkg:npm/%40hapi/hoek@9.3.0",
       "group" : "@hapi",
       "name" : "hoek",
-      "version" : "@9.3.0",
-      "purl" : "pkg:npm/%40hapi/hoek@%409.3.0"
+      "version" : "9.3.0",
+      "purl" : "pkg:npm/%40hapi/hoek@9.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/pinpoint@%402.0.1",
+      "bom-ref" : "pkg:npm/%40hapi/pinpoint@2.0.1",
       "group" : "@hapi",
       "name" : "pinpoint",
-      "version" : "@2.0.1",
-      "purl" : "pkg:npm/%40hapi/pinpoint@%402.0.1"
+      "version" : "2.0.1",
+      "purl" : "pkg:npm/%40hapi/pinpoint@2.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/topo@%405.1.0",
+      "bom-ref" : "pkg:npm/%40hapi/topo@5.1.0",
       "group" : "@hapi",
       "name" : "topo",
-      "version" : "@5.1.0",
-      "purl" : "pkg:npm/%40hapi/topo@%405.1.0"
+      "version" : "5.1.0",
+      "purl" : "pkg:npm/%40hapi/topo@5.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/accepts@%401.3.8",
+      "bom-ref" : "pkg:npm/accepts@1.3.8",
       "name" : "accepts",
-      "version" : "@1.3.8",
-      "purl" : "pkg:npm/accepts@%401.3.8"
+      "version" : "1.3.8",
+      "purl" : "pkg:npm/accepts@1.3.8"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/array-flatten@%401.1.1",
+      "bom-ref" : "pkg:npm/array-flatten@1.1.1",
       "name" : "array-flatten",
-      "version" : "@1.1.1",
-      "purl" : "pkg:npm/array-flatten@%401.1.1"
+      "version" : "1.1.1",
+      "purl" : "pkg:npm/array-flatten@1.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/body-parser@%401.20.3",
+      "bom-ref" : "pkg:npm/body-parser@1.20.3",
       "name" : "body-parser",
-      "version" : "@1.20.3",
-      "purl" : "pkg:npm/body-parser@%401.20.3"
+      "version" : "1.20.3",
+      "purl" : "pkg:npm/body-parser@1.20.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/content-disposition@%400.5.4",
+      "bom-ref" : "pkg:npm/content-disposition@0.5.4",
       "name" : "content-disposition",
-      "version" : "@0.5.4",
-      "purl" : "pkg:npm/content-disposition@%400.5.4"
+      "version" : "0.5.4",
+      "purl" : "pkg:npm/content-disposition@0.5.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/content-type@%401.0.5",
+      "bom-ref" : "pkg:npm/content-type@1.0.5",
       "name" : "content-type",
-      "version" : "@1.0.5",
-      "purl" : "pkg:npm/content-type@%401.0.5"
+      "version" : "1.0.5",
+      "purl" : "pkg:npm/content-type@1.0.5"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/cookie@%400.7.1",
+      "bom-ref" : "pkg:npm/cookie@0.7.1",
       "name" : "cookie",
-      "version" : "@0.7.1",
-      "purl" : "pkg:npm/cookie@%400.7.1"
+      "version" : "0.7.1",
+      "purl" : "pkg:npm/cookie@0.7.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/cookie-signature@%401.0.6",
+      "bom-ref" : "pkg:npm/cookie-signature@1.0.6",
       "name" : "cookie-signature",
-      "version" : "@1.0.6",
-      "purl" : "pkg:npm/cookie-signature@%401.0.6"
+      "version" : "1.0.6",
+      "purl" : "pkg:npm/cookie-signature@1.0.6"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/depd@%402.0.0",
+      "bom-ref" : "pkg:npm/depd@2.0.0",
       "name" : "depd",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/depd@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/depd@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/encodeurl@%402.0.0",
+      "bom-ref" : "pkg:npm/encodeurl@2.0.0",
       "name" : "encodeurl",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/encodeurl@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/encodeurl@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/escape-html@%401.0.3",
+      "bom-ref" : "pkg:npm/escape-html@1.0.3",
       "name" : "escape-html",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/escape-html@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/escape-html@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/etag@%401.8.1",
+      "bom-ref" : "pkg:npm/etag@1.8.1",
       "name" : "etag",
-      "version" : "@1.8.1",
-      "purl" : "pkg:npm/etag@%401.8.1"
+      "version" : "1.8.1",
+      "purl" : "pkg:npm/etag@1.8.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/finalhandler@%401.3.1",
+      "bom-ref" : "pkg:npm/finalhandler@1.3.1",
       "name" : "finalhandler",
-      "version" : "@1.3.1",
-      "purl" : "pkg:npm/finalhandler@%401.3.1"
+      "version" : "1.3.1",
+      "purl" : "pkg:npm/finalhandler@1.3.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/fresh@%400.5.2",
+      "bom-ref" : "pkg:npm/fresh@0.5.2",
       "name" : "fresh",
-      "version" : "@0.5.2",
-      "purl" : "pkg:npm/fresh@%400.5.2"
+      "version" : "0.5.2",
+      "purl" : "pkg:npm/fresh@0.5.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/http-errors@%402.0.0",
+      "bom-ref" : "pkg:npm/http-errors@2.0.0",
       "name" : "http-errors",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/http-errors@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/http-errors@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/merge-descriptors@%401.0.3",
+      "bom-ref" : "pkg:npm/merge-descriptors@1.0.3",
       "name" : "merge-descriptors",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/merge-descriptors@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/merge-descriptors@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/methods@%401.1.2",
+      "bom-ref" : "pkg:npm/methods@1.1.2",
       "name" : "methods",
-      "version" : "@1.1.2",
-      "purl" : "pkg:npm/methods@%401.1.2"
+      "version" : "1.1.2",
+      "purl" : "pkg:npm/methods@1.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/on-finished@%402.4.1",
+      "bom-ref" : "pkg:npm/on-finished@2.4.1",
       "name" : "on-finished",
-      "version" : "@2.4.1",
-      "purl" : "pkg:npm/on-finished@%402.4.1"
+      "version" : "2.4.1",
+      "purl" : "pkg:npm/on-finished@2.4.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/parseurl@%401.3.3",
+      "bom-ref" : "pkg:npm/parseurl@1.3.3",
       "name" : "parseurl",
-      "version" : "@1.3.3",
-      "purl" : "pkg:npm/parseurl@%401.3.3"
+      "version" : "1.3.3",
+      "purl" : "pkg:npm/parseurl@1.3.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/path-to-regexp@%400.1.12",
+      "bom-ref" : "pkg:npm/path-to-regexp@0.1.12",
       "name" : "path-to-regexp",
-      "version" : "@0.1.12",
-      "purl" : "pkg:npm/path-to-regexp@%400.1.12"
+      "version" : "0.1.12",
+      "purl" : "pkg:npm/path-to-regexp@0.1.12"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/proxy-addr@%402.0.7",
+      "bom-ref" : "pkg:npm/proxy-addr@2.0.7",
       "name" : "proxy-addr",
-      "version" : "@2.0.7",
-      "purl" : "pkg:npm/proxy-addr@%402.0.7"
+      "version" : "2.0.7",
+      "purl" : "pkg:npm/proxy-addr@2.0.7"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/qs@%406.13.0",
+      "bom-ref" : "pkg:npm/qs@6.13.0",
       "name" : "qs",
-      "version" : "@6.13.0",
-      "purl" : "pkg:npm/qs@%406.13.0"
+      "version" : "6.13.0",
+      "purl" : "pkg:npm/qs@6.13.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/range-parser@%401.2.1",
+      "bom-ref" : "pkg:npm/range-parser@1.2.1",
       "name" : "range-parser",
-      "version" : "@1.2.1",
-      "purl" : "pkg:npm/range-parser@%401.2.1"
+      "version" : "1.2.1",
+      "purl" : "pkg:npm/range-parser@1.2.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/safe-buffer@%405.2.1",
+      "bom-ref" : "pkg:npm/safe-buffer@5.2.1",
       "name" : "safe-buffer",
-      "version" : "@5.2.1",
-      "purl" : "pkg:npm/safe-buffer@%405.2.1"
+      "version" : "5.2.1",
+      "purl" : "pkg:npm/safe-buffer@5.2.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/send@%400.19.0",
+      "bom-ref" : "pkg:npm/send@0.19.0",
       "name" : "send",
-      "version" : "@0.19.0",
-      "purl" : "pkg:npm/send@%400.19.0"
+      "version" : "0.19.0",
+      "purl" : "pkg:npm/send@0.19.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/serve-static@%401.16.2",
+      "bom-ref" : "pkg:npm/serve-static@1.16.2",
       "name" : "serve-static",
-      "version" : "@1.16.2",
-      "purl" : "pkg:npm/serve-static@%401.16.2"
+      "version" : "1.16.2",
+      "purl" : "pkg:npm/serve-static@1.16.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/setprototypeof@%401.2.0",
+      "bom-ref" : "pkg:npm/setprototypeof@1.2.0",
       "name" : "setprototypeof",
-      "version" : "@1.2.0",
-      "purl" : "pkg:npm/setprototypeof@%401.2.0"
+      "version" : "1.2.0",
+      "purl" : "pkg:npm/setprototypeof@1.2.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/statuses@%402.0.1",
+      "bom-ref" : "pkg:npm/statuses@2.0.1",
       "name" : "statuses",
-      "version" : "@2.0.1",
-      "purl" : "pkg:npm/statuses@%402.0.1"
+      "version" : "2.0.1",
+      "purl" : "pkg:npm/statuses@2.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/type-is@%401.6.18",
+      "bom-ref" : "pkg:npm/type-is@1.6.18",
       "name" : "type-is",
-      "version" : "@1.6.18",
-      "purl" : "pkg:npm/type-is@%401.6.18"
+      "version" : "1.6.18",
+      "purl" : "pkg:npm/type-is@1.6.18"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/utils-merge@%401.0.1",
+      "bom-ref" : "pkg:npm/utils-merge@1.0.1",
       "name" : "utils-merge",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/utils-merge@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/utils-merge@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/vary@%401.1.2",
+      "bom-ref" : "pkg:npm/vary@1.1.2",
       "name" : "vary",
-      "version" : "@1.1.2",
-      "purl" : "pkg:npm/vary@%401.1.2"
+      "version" : "1.1.2",
+      "purl" : "pkg:npm/vary@1.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/jws@%403.2.2",
+      "bom-ref" : "pkg:npm/jws@3.2.2",
       "name" : "jws",
-      "version" : "@3.2.2",
-      "purl" : "pkg:npm/jws@%403.2.2"
+      "version" : "3.2.2",
+      "purl" : "pkg:npm/jws@3.2.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.includes@%404.3.0",
+      "bom-ref" : "pkg:npm/lodash.includes@4.3.0",
       "name" : "lodash.includes",
-      "version" : "@4.3.0",
-      "purl" : "pkg:npm/lodash.includes@%404.3.0"
+      "version" : "4.3.0",
+      "purl" : "pkg:npm/lodash.includes@4.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isboolean@%403.0.3",
+      "bom-ref" : "pkg:npm/lodash.isboolean@3.0.3",
       "name" : "lodash.isboolean",
-      "version" : "@3.0.3",
-      "purl" : "pkg:npm/lodash.isboolean@%403.0.3"
+      "version" : "3.0.3",
+      "purl" : "pkg:npm/lodash.isboolean@3.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isinteger@%404.0.4",
+      "bom-ref" : "pkg:npm/lodash.isinteger@4.0.4",
       "name" : "lodash.isinteger",
-      "version" : "@4.0.4",
-      "purl" : "pkg:npm/lodash.isinteger@%404.0.4"
+      "version" : "4.0.4",
+      "purl" : "pkg:npm/lodash.isinteger@4.0.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isnumber@%403.0.3",
+      "bom-ref" : "pkg:npm/lodash.isnumber@3.0.3",
       "name" : "lodash.isnumber",
-      "version" : "@3.0.3",
-      "purl" : "pkg:npm/lodash.isnumber@%403.0.3"
+      "version" : "3.0.3",
+      "purl" : "pkg:npm/lodash.isnumber@3.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isplainobject@%404.0.6",
+      "bom-ref" : "pkg:npm/lodash.isplainobject@4.0.6",
       "name" : "lodash.isplainobject",
-      "version" : "@4.0.6",
-      "purl" : "pkg:npm/lodash.isplainobject@%404.0.6"
+      "version" : "4.0.6",
+      "purl" : "pkg:npm/lodash.isplainobject@4.0.6"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isstring@%404.0.1",
+      "bom-ref" : "pkg:npm/lodash.isstring@4.0.1",
       "name" : "lodash.isstring",
-      "version" : "@4.0.1",
-      "purl" : "pkg:npm/lodash.isstring@%404.0.1"
+      "version" : "4.0.1",
+      "purl" : "pkg:npm/lodash.isstring@4.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.once@%404.1.1",
+      "bom-ref" : "pkg:npm/lodash.once@4.1.1",
       "name" : "lodash.once",
-      "version" : "@4.1.1",
-      "purl" : "pkg:npm/lodash.once@%404.1.1"
+      "version" : "4.1.1",
+      "purl" : "pkg:npm/lodash.once@4.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/semver@%405.7.2",
+      "bom-ref" : "pkg:npm/semver@5.7.2",
       "name" : "semver",
-      "version" : "@5.7.2",
-      "purl" : "pkg:npm/semver@%405.7.2"
+      "version" : "5.7.2",
+      "purl" : "pkg:npm/semver@5.7.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40types/bson@%404.0.5",
+      "bom-ref" : "pkg:npm/%40types/bson@4.0.5",
       "group" : "@types",
       "name" : "bson",
-      "version" : "@4.0.5",
-      "purl" : "pkg:npm/%40types/bson@%404.0.5"
+      "version" : "4.0.5",
+      "purl" : "pkg:npm/%40types/bson@4.0.5"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40types/mongodb@%403.6.20",
+      "bom-ref" : "pkg:npm/%40types/mongodb@3.6.20",
       "group" : "@types",
       "name" : "mongodb",
-      "version" : "@3.6.20",
-      "purl" : "pkg:npm/%40types/mongodb@%403.6.20"
+      "version" : "3.6.20",
+      "purl" : "pkg:npm/%40types/mongodb@3.6.20"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bson@%401.1.6",
+      "bom-ref" : "pkg:npm/bson@1.1.6",
       "name" : "bson",
-      "version" : "@1.1.6",
-      "purl" : "pkg:npm/bson@%401.1.6"
+      "version" : "1.1.6",
+      "purl" : "pkg:npm/bson@1.1.6"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/kareem@%402.3.2",
+      "bom-ref" : "pkg:npm/kareem@2.3.2",
       "name" : "kareem",
-      "version" : "@2.3.2",
-      "purl" : "pkg:npm/kareem@%402.3.2"
+      "version" : "2.3.2",
+      "purl" : "pkg:npm/kareem@2.3.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mongodb@%403.7.4",
+      "bom-ref" : "pkg:npm/mongodb@3.7.4",
       "name" : "mongodb",
-      "version" : "@3.7.4",
-      "purl" : "pkg:npm/mongodb@%403.7.4"
+      "version" : "3.7.4",
+      "purl" : "pkg:npm/mongodb@3.7.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mongoose-legacy-pluralize@%401.0.2",
+      "bom-ref" : "pkg:npm/mongoose-legacy-pluralize@1.0.2",
       "name" : "mongoose-legacy-pluralize",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/mongoose-legacy-pluralize@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/mongoose-legacy-pluralize@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mpath@%400.8.4",
+      "bom-ref" : "pkg:npm/mpath@0.8.4",
       "name" : "mpath",
-      "version" : "@0.8.4",
-      "purl" : "pkg:npm/mpath@%400.8.4"
+      "version" : "0.8.4",
+      "purl" : "pkg:npm/mpath@0.8.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mquery@%403.2.5",
+      "bom-ref" : "pkg:npm/mquery@3.2.5",
       "name" : "mquery",
-      "version" : "@3.2.5",
-      "purl" : "pkg:npm/mquery@%403.2.5"
+      "version" : "3.2.5",
+      "purl" : "pkg:npm/mquery@3.2.5"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/optional-require@%401.0.3",
+      "bom-ref" : "pkg:npm/optional-require@1.0.3",
       "name" : "optional-require",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/optional-require@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/optional-require@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/regexp-clone@%401.0.0",
+      "bom-ref" : "pkg:npm/regexp-clone@1.0.0",
       "name" : "regexp-clone",
-      "version" : "@1.0.0",
-      "purl" : "pkg:npm/regexp-clone@%401.0.0"
+      "version" : "1.0.0",
+      "purl" : "pkg:npm/regexp-clone@1.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/sift@%4013.5.2",
+      "bom-ref" : "pkg:npm/sift@13.5.2",
       "name" : "sift",
-      "version" : "@13.5.2",
-      "purl" : "pkg:npm/sift@%4013.5.2"
+      "version" : "13.5.2",
+      "purl" : "pkg:npm/sift@13.5.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/sliced@%401.0.1",
+      "bom-ref" : "pkg:npm/sliced@1.0.1",
       "name" : "sliced",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/sliced@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/sliced@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ms@%402.1.2",
+      "bom-ref" : "pkg:npm/ms@2.1.2",
       "name" : "ms",
-      "version" : "@2.1.2",
-      "purl" : "pkg:npm/ms@%402.1.2"
+      "version" : "2.1.2",
+      "purl" : "pkg:npm/ms@2.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/chokidar@%403.6.0",
+      "bom-ref" : "pkg:npm/chokidar@3.6.0",
       "name" : "chokidar",
-      "version" : "@3.6.0",
-      "purl" : "pkg:npm/chokidar@%403.6.0"
+      "version" : "3.6.0",
+      "purl" : "pkg:npm/chokidar@3.6.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ignore-by-default@%401.0.1",
+      "bom-ref" : "pkg:npm/ignore-by-default@1.0.1",
       "name" : "ignore-by-default",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/ignore-by-default@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/ignore-by-default@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/minimatch@%403.1.2",
+      "bom-ref" : "pkg:npm/minimatch@3.1.2",
       "name" : "minimatch",
-      "version" : "@3.1.2",
-      "purl" : "pkg:npm/minimatch@%403.1.2"
+      "version" : "3.1.2",
+      "purl" : "pkg:npm/minimatch@3.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/pstree.remy@%401.1.8",
+      "bom-ref" : "pkg:npm/pstree.remy@1.1.8",
       "name" : "pstree.remy",
-      "version" : "@1.1.8",
-      "purl" : "pkg:npm/pstree.remy@%401.1.8"
+      "version" : "1.1.8",
+      "purl" : "pkg:npm/pstree.remy@1.1.8"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/simple-update-notifier@%401.1.0",
+      "bom-ref" : "pkg:npm/simple-update-notifier@1.1.0",
       "name" : "simple-update-notifier",
-      "version" : "@1.1.0",
-      "purl" : "pkg:npm/simple-update-notifier@%401.1.0"
+      "version" : "1.1.0",
+      "purl" : "pkg:npm/simple-update-notifier@1.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/supports-color@%405.5.0",
+      "bom-ref" : "pkg:npm/supports-color@5.5.0",
       "name" : "supports-color",
-      "version" : "@5.5.0",
-      "purl" : "pkg:npm/supports-color@%405.5.0"
+      "version" : "5.5.0",
+      "purl" : "pkg:npm/supports-color@5.5.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/touch@%403.1.1",
+      "bom-ref" : "pkg:npm/touch@3.1.1",
       "name" : "touch",
-      "version" : "@3.1.1",
-      "purl" : "pkg:npm/touch@%403.1.1"
+      "version" : "3.1.1",
+      "purl" : "pkg:npm/touch@3.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/undefsafe@%402.0.5",
+      "bom-ref" : "pkg:npm/undefsafe@2.0.5",
       "name" : "undefsafe",
-      "version" : "@2.0.5",
-      "purl" : "pkg:npm/undefsafe@%402.0.5"
+      "version" : "2.0.5",
+      "purl" : "pkg:npm/undefsafe@2.0.5"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/debug@%403.2.7",
+      "bom-ref" : "pkg:npm/debug@3.2.7",
       "name" : "debug",
-      "version" : "@3.2.7",
-      "purl" : "pkg:npm/debug@%403.2.7"
+      "version" : "3.2.7",
+      "purl" : "pkg:npm/debug@3.2.7"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/follow-redirects@%401.5.10",
+      "bom-ref" : "pkg:npm/follow-redirects@1.5.10",
       "name" : "follow-redirects",
-      "version" : "@1.5.10",
-      "purl" : "pkg:npm/follow-redirects@%401.5.10"
+      "version" : "1.5.10",
+      "purl" : "pkg:npm/follow-redirects@1.5.10"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40types/node@%4022.14.1",
+      "bom-ref" : "pkg:npm/%40types/node@22.14.1",
       "group" : "@types",
       "name" : "node",
-      "version" : "@22.14.1",
-      "purl" : "pkg:npm/%40types/node@%4022.14.1"
+      "version" : "22.14.1",
+      "purl" : "pkg:npm/%40types/node@22.14.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40types/bson@%404.2.4",
+      "bom-ref" : "pkg:npm/%40types/bson@4.2.4",
       "group" : "@types",
       "name" : "bson",
-      "version" : "@4.2.4",
-      "purl" : "pkg:npm/%40types/bson@%404.2.4"
+      "version" : "4.2.4",
+      "purl" : "pkg:npm/%40types/bson@4.2.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bson@%406.10.3",
+      "bom-ref" : "pkg:npm/bson@6.10.3",
       "name" : "bson",
-      "version" : "@6.10.3",
-      "purl" : "pkg:npm/bson@%406.10.3"
+      "version" : "6.10.3",
+      "purl" : "pkg:npm/bson@6.10.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mime-types@%402.1.35",
+      "bom-ref" : "pkg:npm/mime-types@2.1.35",
       "name" : "mime-types",
-      "version" : "@2.1.35",
-      "purl" : "pkg:npm/mime-types@%402.1.35"
+      "version" : "2.1.35",
+      "purl" : "pkg:npm/mime-types@2.1.35"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/negotiator@%400.6.3",
+      "bom-ref" : "pkg:npm/negotiator@0.6.3",
       "name" : "negotiator",
-      "version" : "@0.6.3",
-      "purl" : "pkg:npm/negotiator@%400.6.3"
+      "version" : "0.6.3",
+      "purl" : "pkg:npm/negotiator@0.6.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bytes@%403.1.2",
+      "bom-ref" : "pkg:npm/bytes@3.1.2",
       "name" : "bytes",
-      "version" : "@3.1.2",
-      "purl" : "pkg:npm/bytes@%403.1.2"
+      "version" : "3.1.2",
+      "purl" : "pkg:npm/bytes@3.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/destroy@%401.2.0",
+      "bom-ref" : "pkg:npm/destroy@1.2.0",
       "name" : "destroy",
-      "version" : "@1.2.0",
-      "purl" : "pkg:npm/destroy@%401.2.0"
+      "version" : "1.2.0",
+      "purl" : "pkg:npm/destroy@1.2.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/iconv-lite@%400.4.24",
+      "bom-ref" : "pkg:npm/iconv-lite@0.4.24",
       "name" : "iconv-lite",
-      "version" : "@0.4.24",
-      "purl" : "pkg:npm/iconv-lite@%400.4.24"
+      "version" : "0.4.24",
+      "purl" : "pkg:npm/iconv-lite@0.4.24"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/raw-body@%402.5.2",
+      "bom-ref" : "pkg:npm/raw-body@2.5.2",
       "name" : "raw-body",
-      "version" : "@2.5.2",
-      "purl" : "pkg:npm/raw-body@%402.5.2"
+      "version" : "2.5.2",
+      "purl" : "pkg:npm/raw-body@2.5.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/unpipe@%401.0.0",
+      "bom-ref" : "pkg:npm/unpipe@1.0.0",
       "name" : "unpipe",
-      "version" : "@1.0.0",
-      "purl" : "pkg:npm/unpipe@%401.0.0"
+      "version" : "1.0.0",
+      "purl" : "pkg:npm/unpipe@1.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/anymatch@%403.1.3",
+      "bom-ref" : "pkg:npm/anymatch@3.1.3",
       "name" : "anymatch",
-      "version" : "@3.1.3",
-      "purl" : "pkg:npm/anymatch@%403.1.3"
+      "version" : "3.1.3",
+      "purl" : "pkg:npm/anymatch@3.1.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/braces@%403.0.3",
+      "bom-ref" : "pkg:npm/braces@3.0.3",
       "name" : "braces",
-      "version" : "@3.0.3",
-      "purl" : "pkg:npm/braces@%403.0.3"
+      "version" : "3.0.3",
+      "purl" : "pkg:npm/braces@3.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/glob-parent@%405.1.2",
+      "bom-ref" : "pkg:npm/glob-parent@5.1.2",
       "name" : "glob-parent",
-      "version" : "@5.1.2",
-      "purl" : "pkg:npm/glob-parent@%405.1.2"
+      "version" : "5.1.2",
+      "purl" : "pkg:npm/glob-parent@5.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/is-binary-path@%402.1.0",
+      "bom-ref" : "pkg:npm/is-binary-path@2.1.0",
       "name" : "is-binary-path",
-      "version" : "@2.1.0",
-      "purl" : "pkg:npm/is-binary-path@%402.1.0"
+      "version" : "2.1.0",
+      "purl" : "pkg:npm/is-binary-path@2.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/is-glob@%404.0.3",
+      "bom-ref" : "pkg:npm/is-glob@4.0.3",
       "name" : "is-glob",
-      "version" : "@4.0.3",
-      "purl" : "pkg:npm/is-glob@%404.0.3"
+      "version" : "4.0.3",
+      "purl" : "pkg:npm/is-glob@4.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/normalize-path@%403.0.0",
+      "bom-ref" : "pkg:npm/normalize-path@3.0.0",
       "name" : "normalize-path",
-      "version" : "@3.0.0",
-      "purl" : "pkg:npm/normalize-path@%403.0.0"
+      "version" : "3.0.0",
+      "purl" : "pkg:npm/normalize-path@3.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/readdirp@%403.6.0",
+      "bom-ref" : "pkg:npm/readdirp@3.6.0",
       "name" : "readdirp",
-      "version" : "@3.6.0",
-      "purl" : "pkg:npm/readdirp@%403.6.0"
+      "version" : "3.6.0",
+      "purl" : "pkg:npm/readdirp@3.6.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/fsevents@%402.3.3",
+      "bom-ref" : "pkg:npm/fsevents@2.3.3",
       "name" : "fsevents",
-      "version" : "@2.3.3",
-      "purl" : "pkg:npm/fsevents@%402.3.3"
+      "version" : "2.3.3",
+      "purl" : "pkg:npm/fsevents@2.3.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/debug@%403.1.0",
+      "bom-ref" : "pkg:npm/debug@3.1.0",
       "name" : "debug",
-      "version" : "@3.1.0",
-      "purl" : "pkg:npm/debug@%403.1.0"
+      "version" : "3.1.0",
+      "purl" : "pkg:npm/debug@3.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/inherits@%402.0.4",
+      "bom-ref" : "pkg:npm/inherits@2.0.4",
       "name" : "inherits",
-      "version" : "@2.0.4",
-      "purl" : "pkg:npm/inherits@%402.0.4"
+      "version" : "2.0.4",
+      "purl" : "pkg:npm/inherits@2.0.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/toidentifier@%401.0.1",
+      "bom-ref" : "pkg:npm/toidentifier@1.0.1",
       "name" : "toidentifier",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/toidentifier@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/toidentifier@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/jwa@%401.4.1",
+      "bom-ref" : "pkg:npm/jwa@1.4.1",
       "name" : "jwa",
-      "version" : "@1.4.1",
-      "purl" : "pkg:npm/jwa@%401.4.1"
+      "version" : "1.4.1",
+      "purl" : "pkg:npm/jwa@1.4.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/brace-expansion@%401.1.11",
+      "bom-ref" : "pkg:npm/brace-expansion@1.1.11",
       "name" : "brace-expansion",
-      "version" : "@1.1.11",
-      "purl" : "pkg:npm/brace-expansion@%401.1.11"
+      "version" : "1.1.11",
+      "purl" : "pkg:npm/brace-expansion@1.1.11"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bl@%402.2.1",
+      "bom-ref" : "pkg:npm/bl@2.2.1",
       "name" : "bl",
-      "version" : "@2.2.1",
-      "purl" : "pkg:npm/bl@%402.2.1"
+      "version" : "2.2.1",
+      "purl" : "pkg:npm/bl@2.2.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/denque@%401.5.1",
+      "bom-ref" : "pkg:npm/denque@1.5.1",
       "name" : "denque",
-      "version" : "@1.5.1",
-      "purl" : "pkg:npm/denque@%401.5.1"
+      "version" : "1.5.1",
+      "purl" : "pkg:npm/denque@1.5.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/saslprep@%401.0.3",
+      "bom-ref" : "pkg:npm/saslprep@1.0.3",
       "name" : "saslprep",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/saslprep@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/saslprep@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/optional-require@%401.1.8",
+      "bom-ref" : "pkg:npm/optional-require@1.1.8",
       "name" : "optional-require",
-      "version" : "@1.1.8",
-      "purl" : "pkg:npm/optional-require@%401.1.8"
+      "version" : "1.1.8",
+      "purl" : "pkg:npm/optional-require@1.1.8"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/require-at@%401.0.6",
+      "bom-ref" : "pkg:npm/require-at@1.0.6",
       "name" : "require-at",
-      "version" : "@1.0.6",
-      "purl" : "pkg:npm/require-at@%401.0.6"
+      "version" : "1.0.6",
+      "purl" : "pkg:npm/require-at@1.0.6"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bluebird@%403.5.1",
+      "bom-ref" : "pkg:npm/bluebird@3.5.1",
       "name" : "bluebird",
-      "version" : "@3.5.1",
-      "purl" : "pkg:npm/bluebird@%403.5.1"
+      "version" : "3.5.1",
+      "purl" : "pkg:npm/bluebird@3.5.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/safe-buffer@%405.1.2",
+      "bom-ref" : "pkg:npm/safe-buffer@5.1.2",
       "name" : "safe-buffer",
-      "version" : "@5.1.2",
-      "purl" : "pkg:npm/safe-buffer@%405.1.2"
+      "version" : "5.1.2",
+      "purl" : "pkg:npm/safe-buffer@5.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ee-first@%401.1.1",
+      "bom-ref" : "pkg:npm/ee-first@1.1.1",
       "name" : "ee-first",
-      "version" : "@1.1.1",
-      "purl" : "pkg:npm/ee-first@%401.1.1"
+      "version" : "1.1.1",
+      "purl" : "pkg:npm/ee-first@1.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/forwarded@%400.2.0",
+      "bom-ref" : "pkg:npm/forwarded@0.2.0",
       "name" : "forwarded",
-      "version" : "@0.2.0",
-      "purl" : "pkg:npm/forwarded@%400.2.0"
+      "version" : "0.2.0",
+      "purl" : "pkg:npm/forwarded@0.2.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ipaddr.js@%401.9.1",
+      "bom-ref" : "pkg:npm/ipaddr.js@1.9.1",
       "name" : "ipaddr.js",
-      "version" : "@1.9.1",
-      "purl" : "pkg:npm/ipaddr.js@%401.9.1"
+      "version" : "1.9.1",
+      "purl" : "pkg:npm/ipaddr.js@1.9.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/side-channel@%401.1.0",
+      "bom-ref" : "pkg:npm/side-channel@1.1.0",
       "name" : "side-channel",
-      "version" : "@1.1.0",
-      "purl" : "pkg:npm/side-channel@%401.1.0"
+      "version" : "1.1.0",
+      "purl" : "pkg:npm/side-channel@1.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mime@%401.6.0",
+      "bom-ref" : "pkg:npm/mime@1.6.0",
       "name" : "mime",
-      "version" : "@1.6.0",
-      "purl" : "pkg:npm/mime@%401.6.0"
+      "version" : "1.6.0",
+      "purl" : "pkg:npm/mime@1.6.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/encodeurl@%401.0.2",
+      "bom-ref" : "pkg:npm/encodeurl@1.0.2",
       "name" : "encodeurl",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/encodeurl@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/encodeurl@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/semver@%407.0.0",
+      "bom-ref" : "pkg:npm/semver@7.0.0",
       "name" : "semver",
-      "version" : "@7.0.0",
-      "purl" : "pkg:npm/semver@%407.0.0"
+      "version" : "7.0.0",
+      "purl" : "pkg:npm/semver@7.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/has-flag@%403.0.0",
+      "bom-ref" : "pkg:npm/has-flag@3.0.0",
       "name" : "has-flag",
-      "version" : "@3.0.0",
-      "purl" : "pkg:npm/has-flag@%403.0.0"
+      "version" : "3.0.0",
+      "purl" : "pkg:npm/has-flag@3.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/media-typer@%400.3.0",
+      "bom-ref" : "pkg:npm/media-typer@0.3.0",
       "name" : "media-typer",
-      "version" : "@0.3.0",
-      "purl" : "pkg:npm/media-typer@%400.3.0"
+      "version" : "0.3.0",
+      "purl" : "pkg:npm/media-typer@0.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/undici-types@%406.21.0",
+      "bom-ref" : "pkg:npm/undici-types@6.21.0",
       "name" : "undici-types",
-      "version" : "@6.21.0",
-      "purl" : "pkg:npm/undici-types@%406.21.0"
+      "version" : "6.21.0",
+      "purl" : "pkg:npm/undici-types@6.21.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/picomatch@%402.3.1",
+      "bom-ref" : "pkg:npm/picomatch@2.3.1",
       "name" : "picomatch",
-      "version" : "@2.3.1",
-      "purl" : "pkg:npm/picomatch@%402.3.1"
+      "version" : "2.3.1",
+      "purl" : "pkg:npm/picomatch@2.3.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/readable-stream@%402.3.8",
+      "bom-ref" : "pkg:npm/readable-stream@2.3.8",
       "name" : "readable-stream",
-      "version" : "@2.3.8",
-      "purl" : "pkg:npm/readable-stream@%402.3.8"
+      "version" : "2.3.8",
+      "purl" : "pkg:npm/readable-stream@2.3.8"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/balanced-match@%401.0.2",
+      "bom-ref" : "pkg:npm/balanced-match@1.0.2",
       "name" : "balanced-match",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/balanced-match@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/balanced-match@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/concat-map@%400.0.1",
+      "bom-ref" : "pkg:npm/concat-map@0.0.1",
       "name" : "concat-map",
-      "version" : "@0.0.1",
-      "purl" : "pkg:npm/concat-map@%400.0.1"
+      "version" : "0.0.1",
+      "purl" : "pkg:npm/concat-map@0.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/fill-range@%407.1.1",
+      "bom-ref" : "pkg:npm/fill-range@7.1.1",
       "name" : "fill-range",
-      "version" : "@7.1.1",
-      "purl" : "pkg:npm/fill-range@%407.1.1"
+      "version" : "7.1.1",
+      "purl" : "pkg:npm/fill-range@7.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/safer-buffer@%402.1.2",
+      "bom-ref" : "pkg:npm/safer-buffer@2.1.2",
       "name" : "safer-buffer",
-      "version" : "@2.1.2",
-      "purl" : "pkg:npm/safer-buffer@%402.1.2"
+      "version" : "2.1.2",
+      "purl" : "pkg:npm/safer-buffer@2.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/binary-extensions@%402.3.0",
+      "bom-ref" : "pkg:npm/binary-extensions@2.3.0",
       "name" : "binary-extensions",
-      "version" : "@2.3.0",
-      "purl" : "pkg:npm/binary-extensions@%402.3.0"
+      "version" : "2.3.0",
+      "purl" : "pkg:npm/binary-extensions@2.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/is-extglob@%402.1.1",
+      "bom-ref" : "pkg:npm/is-extglob@2.1.1",
       "name" : "is-extglob",
-      "version" : "@2.1.1",
-      "purl" : "pkg:npm/is-extglob@%402.1.1"
+      "version" : "2.1.1",
+      "purl" : "pkg:npm/is-extglob@2.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/buffer-equal-constant-time@%401.0.1",
+      "bom-ref" : "pkg:npm/buffer-equal-constant-time@1.0.1",
       "name" : "buffer-equal-constant-time",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/buffer-equal-constant-time@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/buffer-equal-constant-time@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ecdsa-sig-formatter@%401.0.11",
+      "bom-ref" : "pkg:npm/ecdsa-sig-formatter@1.0.11",
       "name" : "ecdsa-sig-formatter",
-      "version" : "@1.0.11",
-      "purl" : "pkg:npm/ecdsa-sig-formatter@%401.0.11"
+      "version" : "1.0.11",
+      "purl" : "pkg:npm/ecdsa-sig-formatter@1.0.11"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mime-db@%401.52.0",
+      "bom-ref" : "pkg:npm/mime-db@1.52.0",
       "name" : "mime-db",
-      "version" : "@1.52.0",
-      "purl" : "pkg:npm/mime-db@%401.52.0"
+      "version" : "1.52.0",
+      "purl" : "pkg:npm/mime-db@1.52.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/sparse-bitfield@%403.0.3",
+      "bom-ref" : "pkg:npm/sparse-bitfield@3.0.3",
       "name" : "sparse-bitfield",
-      "version" : "@3.0.3",
-      "purl" : "pkg:npm/sparse-bitfield@%403.0.3"
+      "version" : "3.0.3",
+      "purl" : "pkg:npm/sparse-bitfield@3.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/es-errors@%401.3.0",
+      "bom-ref" : "pkg:npm/es-errors@1.3.0",
       "name" : "es-errors",
-      "version" : "@1.3.0",
-      "purl" : "pkg:npm/es-errors@%401.3.0"
+      "version" : "1.3.0",
+      "purl" : "pkg:npm/es-errors@1.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/object-inspect@%401.13.4",
+      "bom-ref" : "pkg:npm/object-inspect@1.13.4",
       "name" : "object-inspect",
-      "version" : "@1.13.4",
-      "purl" : "pkg:npm/object-inspect@%401.13.4"
+      "version" : "1.13.4",
+      "purl" : "pkg:npm/object-inspect@1.13.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/side-channel-list@%401.0.0",
+      "bom-ref" : "pkg:npm/side-channel-list@1.0.0",
       "name" : "side-channel-list",
-      "version" : "@1.0.0",
-      "purl" : "pkg:npm/side-channel-list@%401.0.0"
+      "version" : "1.0.0",
+      "purl" : "pkg:npm/side-channel-list@1.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/side-channel-map@%401.0.1",
+      "bom-ref" : "pkg:npm/side-channel-map@1.0.1",
       "name" : "side-channel-map",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/side-channel-map@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/side-channel-map@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/side-channel-weakmap@%401.0.2",
+      "bom-ref" : "pkg:npm/side-channel-weakmap@1.0.2",
       "name" : "side-channel-weakmap",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/side-channel-weakmap@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/side-channel-weakmap@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/to-regex-range@%405.0.1",
+      "bom-ref" : "pkg:npm/to-regex-range@5.0.1",
       "name" : "to-regex-range",
-      "version" : "@5.0.1",
-      "purl" : "pkg:npm/to-regex-range@%405.0.1"
+      "version" : "5.0.1",
+      "purl" : "pkg:npm/to-regex-range@5.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/core-util-is@%401.0.3",
+      "bom-ref" : "pkg:npm/core-util-is@1.0.3",
       "name" : "core-util-is",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/core-util-is@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/core-util-is@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/isarray@%401.0.0",
+      "bom-ref" : "pkg:npm/isarray@1.0.0",
       "name" : "isarray",
-      "version" : "@1.0.0",
-      "purl" : "pkg:npm/isarray@%401.0.0"
+      "version" : "1.0.0",
+      "purl" : "pkg:npm/isarray@1.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/process-nextick-args@%402.0.1",
+      "bom-ref" : "pkg:npm/process-nextick-args@2.0.1",
       "name" : "process-nextick-args",
-      "version" : "@2.0.1",
-      "purl" : "pkg:npm/process-nextick-args@%402.0.1"
+      "version" : "2.0.1",
+      "purl" : "pkg:npm/process-nextick-args@2.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/string_decoder@%401.1.1",
+      "bom-ref" : "pkg:npm/string_decoder@1.1.1",
       "name" : "string_decoder",
-      "version" : "@1.1.1",
-      "purl" : "pkg:npm/string_decoder@%401.1.1"
+      "version" : "1.1.1",
+      "purl" : "pkg:npm/string_decoder@1.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/util-deprecate@%401.0.2",
+      "bom-ref" : "pkg:npm/util-deprecate@1.0.2",
       "name" : "util-deprecate",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/util-deprecate@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/util-deprecate@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/call-bound@%401.0.4",
+      "bom-ref" : "pkg:npm/call-bound@1.0.4",
       "name" : "call-bound",
-      "version" : "@1.0.4",
-      "purl" : "pkg:npm/call-bound@%401.0.4"
+      "version" : "1.0.4",
+      "purl" : "pkg:npm/call-bound@1.0.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/get-intrinsic@%401.3.0",
+      "bom-ref" : "pkg:npm/get-intrinsic@1.3.0",
       "name" : "get-intrinsic",
-      "version" : "@1.3.0",
-      "purl" : "pkg:npm/get-intrinsic@%401.3.0"
+      "version" : "1.3.0",
+      "purl" : "pkg:npm/get-intrinsic@1.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/memory-pager@%401.5.0",
+      "bom-ref" : "pkg:npm/memory-pager@1.5.0",
       "name" : "memory-pager",
-      "version" : "@1.5.0",
-      "purl" : "pkg:npm/memory-pager@%401.5.0"
+      "version" : "1.5.0",
+      "purl" : "pkg:npm/memory-pager@1.5.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/call-bind-apply-helpers@%401.0.2",
+      "bom-ref" : "pkg:npm/call-bind-apply-helpers@1.0.2",
       "name" : "call-bind-apply-helpers",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/call-bind-apply-helpers@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/call-bind-apply-helpers@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/es-define-property@%401.0.1",
+      "bom-ref" : "pkg:npm/es-define-property@1.0.1",
       "name" : "es-define-property",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/es-define-property@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/es-define-property@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/es-object-atoms@%401.1.1",
+      "bom-ref" : "pkg:npm/es-object-atoms@1.1.1",
       "name" : "es-object-atoms",
-      "version" : "@1.1.1",
-      "purl" : "pkg:npm/es-object-atoms@%401.1.1"
+      "version" : "1.1.1",
+      "purl" : "pkg:npm/es-object-atoms@1.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/function-bind@%401.1.2",
+      "bom-ref" : "pkg:npm/function-bind@1.1.2",
       "name" : "function-bind",
-      "version" : "@1.1.2",
-      "purl" : "pkg:npm/function-bind@%401.1.2"
+      "version" : "1.1.2",
+      "purl" : "pkg:npm/function-bind@1.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/get-proto@%401.0.1",
+      "bom-ref" : "pkg:npm/get-proto@1.0.1",
       "name" : "get-proto",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/get-proto@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/get-proto@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/gopd@%401.2.0",
+      "bom-ref" : "pkg:npm/gopd@1.2.0",
       "name" : "gopd",
-      "version" : "@1.2.0",
-      "purl" : "pkg:npm/gopd@%401.2.0"
+      "version" : "1.2.0",
+      "purl" : "pkg:npm/gopd@1.2.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/has-symbols@%401.1.0",
+      "bom-ref" : "pkg:npm/has-symbols@1.1.0",
       "name" : "has-symbols",
-      "version" : "@1.1.0",
-      "purl" : "pkg:npm/has-symbols@%401.1.0"
+      "version" : "1.1.0",
+      "purl" : "pkg:npm/has-symbols@1.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/hasown@%402.0.2",
+      "bom-ref" : "pkg:npm/hasown@2.0.2",
       "name" : "hasown",
-      "version" : "@2.0.2",
-      "purl" : "pkg:npm/hasown@%402.0.2"
+      "version" : "2.0.2",
+      "purl" : "pkg:npm/hasown@2.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/math-intrinsics@%401.1.0",
+      "bom-ref" : "pkg:npm/math-intrinsics@1.1.0",
       "name" : "math-intrinsics",
-      "version" : "@1.1.0",
-      "purl" : "pkg:npm/math-intrinsics@%401.1.0"
+      "version" : "1.1.0",
+      "purl" : "pkg:npm/math-intrinsics@1.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/is-number@%407.0.0",
+      "bom-ref" : "pkg:npm/is-number@7.0.0",
       "name" : "is-number",
-      "version" : "@7.0.0",
-      "purl" : "pkg:npm/is-number@%407.0.0"
+      "version" : "7.0.0",
+      "purl" : "pkg:npm/is-number@7.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/dunder-proto@%401.0.1",
+      "bom-ref" : "pkg:npm/dunder-proto@1.0.1",
       "name" : "dunder-proto",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/dunder-proto@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/dunder-proto@1.0.1"
     }
   ],
   "dependencies" : [
     {
       "ref" : "pkg:npm/backend@1.0.0",
       "dependsOn" : [
-        "pkg:npm/%40hapi/joi@%4017.1.1",
-        "pkg:npm/backend@%400.0.0",
-        "pkg:npm/bcryptjs@%402.4.3",
-        "pkg:npm/dotenv@%408.6.0",
-        "pkg:npm/express@%404.21.2",
-        "pkg:npm/mongoose@%405.13.23",
-        "pkg:npm/nodemon@%402.0.22",
-        "pkg:npm/axios@%400.19.2"
+        "pkg:npm/%40hapi/joi@17.1.1",
+        "pkg:npm/backend@0.0.0",
+        "pkg:npm/bcryptjs@2.4.3",
+        "pkg:npm/dotenv@8.6.0",
+        "pkg:npm/express@4.21.2",
+        "pkg:npm/mongoose@5.13.23",
+        "pkg:npm/nodemon@2.0.22",
+        "pkg:npm/axios@0.19.2"
       ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/joi@%4017.1.1",
+      "ref" : "pkg:npm/%40hapi/joi@17.1.1",
       "dependsOn" : [
-        "pkg:npm/%40hapi/address@%404.1.0",
-        "pkg:npm/%40hapi/formula@%402.0.0",
-        "pkg:npm/%40hapi/hoek@%409.3.0",
-        "pkg:npm/%40hapi/pinpoint@%402.0.1",
-        "pkg:npm/%40hapi/topo@%405.1.0"
+        "pkg:npm/%40hapi/address@4.1.0",
+        "pkg:npm/%40hapi/formula@2.0.0",
+        "pkg:npm/%40hapi/hoek@9.3.0",
+        "pkg:npm/%40hapi/pinpoint@2.0.1",
+        "pkg:npm/%40hapi/topo@5.1.0"
       ]
     },
     {
-      "ref" : "pkg:npm/backend@%400.0.0",
+      "ref" : "pkg:npm/backend@0.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/bcryptjs@%402.4.3",
+      "ref" : "pkg:npm/bcryptjs@2.4.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/dotenv@%408.6.0",
+      "ref" : "pkg:npm/dotenv@8.6.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/express@%404.21.2",
+      "ref" : "pkg:npm/express@4.21.2",
       "dependsOn" : [
-        "pkg:npm/accepts@%401.3.8",
-        "pkg:npm/array-flatten@%401.1.1",
-        "pkg:npm/body-parser@%401.20.3",
-        "pkg:npm/content-disposition@%400.5.4",
-        "pkg:npm/content-type@%401.0.5",
-        "pkg:npm/cookie@%400.7.1",
-        "pkg:npm/cookie-signature@%401.0.6",
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/depd@%402.0.0",
-        "pkg:npm/encodeurl@%402.0.0",
-        "pkg:npm/escape-html@%401.0.3",
-        "pkg:npm/etag@%401.8.1",
-        "pkg:npm/finalhandler@%401.3.1",
-        "pkg:npm/fresh@%400.5.2",
-        "pkg:npm/http-errors@%402.0.0",
-        "pkg:npm/merge-descriptors@%401.0.3",
-        "pkg:npm/methods@%401.1.2",
-        "pkg:npm/on-finished@%402.4.1",
-        "pkg:npm/parseurl@%401.3.3",
-        "pkg:npm/path-to-regexp@%400.1.12",
-        "pkg:npm/proxy-addr@%402.0.7",
-        "pkg:npm/qs@%406.13.0",
-        "pkg:npm/range-parser@%401.2.1",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/send@%400.19.0",
-        "pkg:npm/serve-static@%401.16.2",
-        "pkg:npm/setprototypeof@%401.2.0",
-        "pkg:npm/statuses@%402.0.1",
-        "pkg:npm/type-is@%401.6.18",
-        "pkg:npm/utils-merge@%401.0.1",
-        "pkg:npm/vary@%401.1.2"
+        "pkg:npm/accepts@1.3.8",
+        "pkg:npm/array-flatten@1.1.1",
+        "pkg:npm/body-parser@1.20.3",
+        "pkg:npm/content-disposition@0.5.4",
+        "pkg:npm/content-type@1.0.5",
+        "pkg:npm/cookie@0.7.1",
+        "pkg:npm/cookie-signature@1.0.6",
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/depd@2.0.0",
+        "pkg:npm/encodeurl@2.0.0",
+        "pkg:npm/escape-html@1.0.3",
+        "pkg:npm/etag@1.8.1",
+        "pkg:npm/finalhandler@1.3.1",
+        "pkg:npm/fresh@0.5.2",
+        "pkg:npm/http-errors@2.0.0",
+        "pkg:npm/merge-descriptors@1.0.3",
+        "pkg:npm/methods@1.1.2",
+        "pkg:npm/on-finished@2.4.1",
+        "pkg:npm/parseurl@1.3.3",
+        "pkg:npm/path-to-regexp@0.1.12",
+        "pkg:npm/proxy-addr@2.0.7",
+        "pkg:npm/qs@6.13.0",
+        "pkg:npm/range-parser@1.2.1",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/send@0.19.0",
+        "pkg:npm/serve-static@1.16.2",
+        "pkg:npm/setprototypeof@1.2.0",
+        "pkg:npm/statuses@2.0.1",
+        "pkg:npm/type-is@1.6.18",
+        "pkg:npm/utils-merge@1.0.1",
+        "pkg:npm/vary@1.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/mongoose@%405.13.23",
+      "ref" : "pkg:npm/mongoose@5.13.23",
       "dependsOn" : [
-        "pkg:npm/%40types/bson@%404.0.5",
-        "pkg:npm/%40types/mongodb@%403.6.20",
-        "pkg:npm/bson@%401.1.6",
-        "pkg:npm/kareem@%402.3.2",
-        "pkg:npm/mongodb@%403.7.4",
-        "pkg:npm/mongoose-legacy-pluralize@%401.0.2",
-        "pkg:npm/mpath@%400.8.4",
-        "pkg:npm/mquery@%403.2.5",
-        "pkg:npm/ms@%402.1.3",
-        "pkg:npm/optional-require@%401.0.3",
-        "pkg:npm/regexp-clone@%401.0.0",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/sift@%4013.5.2",
-        "pkg:npm/sliced@%401.0.1",
-        "pkg:npm/ms@%402.1.2"
+        "pkg:npm/%40types/bson@4.0.5",
+        "pkg:npm/%40types/mongodb@3.6.20",
+        "pkg:npm/bson@1.1.6",
+        "pkg:npm/kareem@2.3.2",
+        "pkg:npm/mongodb@3.7.4",
+        "pkg:npm/mongoose-legacy-pluralize@1.0.2",
+        "pkg:npm/mpath@0.8.4",
+        "pkg:npm/mquery@3.2.5",
+        "pkg:npm/ms@2.1.3",
+        "pkg:npm/optional-require@1.0.3",
+        "pkg:npm/regexp-clone@1.0.0",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/sift@13.5.2",
+        "pkg:npm/sliced@1.0.1",
+        "pkg:npm/ms@2.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/nodemon@%402.0.22",
+      "ref" : "pkg:npm/nodemon@2.0.22",
       "dependsOn" : [
-        "pkg:npm/chokidar@%403.6.0",
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/ignore-by-default@%401.0.1",
-        "pkg:npm/minimatch@%403.1.2",
-        "pkg:npm/pstree.remy@%401.1.8",
-        "pkg:npm/semver@%405.7.2",
-        "pkg:npm/simple-update-notifier@%401.1.0",
-        "pkg:npm/supports-color@%405.5.0",
-        "pkg:npm/touch@%403.1.1",
-        "pkg:npm/undefsafe@%402.0.5",
-        "pkg:npm/debug@%403.2.7"
+        "pkg:npm/chokidar@3.6.0",
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/ignore-by-default@1.0.1",
+        "pkg:npm/minimatch@3.1.2",
+        "pkg:npm/pstree.remy@1.1.8",
+        "pkg:npm/semver@5.7.2",
+        "pkg:npm/simple-update-notifier@1.1.0",
+        "pkg:npm/supports-color@5.5.0",
+        "pkg:npm/touch@3.1.1",
+        "pkg:npm/undefsafe@2.0.5",
+        "pkg:npm/debug@3.2.7"
       ]
     },
     {
-      "ref" : "pkg:npm/axios@%400.19.2",
+      "ref" : "pkg:npm/axios@0.19.2",
       "dependsOn" : [
-        "pkg:npm/follow-redirects@%401.5.10"
+        "pkg:npm/follow-redirects@1.5.10"
       ]
     },
     {
-      "ref" : "pkg:npm/debug@%402.6.9",
+      "ref" : "pkg:npm/debug@2.6.9",
       "dependsOn" : [
-        "pkg:npm/ms@%402.1.3",
-        "pkg:npm/ms@%402.0.0"
+        "pkg:npm/ms@2.1.3",
+        "pkg:npm/ms@2.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/ms@%402.1.3",
+      "ref" : "pkg:npm/ms@2.1.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ms@%402.0.0",
+      "ref" : "pkg:npm/ms@2.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/address@%404.1.0",
+      "ref" : "pkg:npm/%40hapi/address@4.1.0",
       "dependsOn" : [
-        "pkg:npm/%40hapi/hoek@%409.3.0"
+        "pkg:npm/%40hapi/hoek@9.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/formula@%402.0.0",
+      "ref" : "pkg:npm/%40hapi/formula@2.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/hoek@%409.3.0",
+      "ref" : "pkg:npm/%40hapi/hoek@9.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/pinpoint@%402.0.1",
+      "ref" : "pkg:npm/%40hapi/pinpoint@2.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/topo@%405.1.0",
+      "ref" : "pkg:npm/%40hapi/topo@5.1.0",
       "dependsOn" : [
-        "pkg:npm/%40hapi/hoek@%409.3.0"
+        "pkg:npm/%40hapi/hoek@9.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/accepts@%401.3.8",
+      "ref" : "pkg:npm/accepts@1.3.8",
       "dependsOn" : [
-        "pkg:npm/mime-types@%402.1.35",
-        "pkg:npm/negotiator@%400.6.3"
+        "pkg:npm/mime-types@2.1.35",
+        "pkg:npm/negotiator@0.6.3"
       ]
     },
     {
-      "ref" : "pkg:npm/array-flatten@%401.1.1",
+      "ref" : "pkg:npm/array-flatten@1.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/body-parser@%401.20.3",
+      "ref" : "pkg:npm/body-parser@1.20.3",
       "dependsOn" : [
-        "pkg:npm/bytes@%403.1.2",
-        "pkg:npm/content-type@%401.0.5",
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/depd@%402.0.0",
-        "pkg:npm/destroy@%401.2.0",
-        "pkg:npm/http-errors@%402.0.0",
-        "pkg:npm/iconv-lite@%400.4.24",
-        "pkg:npm/on-finished@%402.4.1",
-        "pkg:npm/qs@%406.13.0",
-        "pkg:npm/raw-body@%402.5.2",
-        "pkg:npm/type-is@%401.6.18",
-        "pkg:npm/unpipe@%401.0.0"
+        "pkg:npm/bytes@3.1.2",
+        "pkg:npm/content-type@1.0.5",
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/depd@2.0.0",
+        "pkg:npm/destroy@1.2.0",
+        "pkg:npm/http-errors@2.0.0",
+        "pkg:npm/iconv-lite@0.4.24",
+        "pkg:npm/on-finished@2.4.1",
+        "pkg:npm/qs@6.13.0",
+        "pkg:npm/raw-body@2.5.2",
+        "pkg:npm/type-is@1.6.18",
+        "pkg:npm/unpipe@1.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/content-disposition@%400.5.4",
+      "ref" : "pkg:npm/content-disposition@0.5.4",
       "dependsOn" : [
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/content-type@%401.0.5",
+      "ref" : "pkg:npm/content-type@1.0.5",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/cookie@%400.7.1",
+      "ref" : "pkg:npm/cookie@0.7.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/cookie-signature@%401.0.6",
+      "ref" : "pkg:npm/cookie-signature@1.0.6",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/depd@%402.0.0",
+      "ref" : "pkg:npm/depd@2.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/encodeurl@%402.0.0",
+      "ref" : "pkg:npm/encodeurl@2.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/escape-html@%401.0.3",
+      "ref" : "pkg:npm/escape-html@1.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/etag@%401.8.1",
+      "ref" : "pkg:npm/etag@1.8.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/finalhandler@%401.3.1",
+      "ref" : "pkg:npm/finalhandler@1.3.1",
       "dependsOn" : [
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/encodeurl@%402.0.0",
-        "pkg:npm/escape-html@%401.0.3",
-        "pkg:npm/on-finished@%402.4.1",
-        "pkg:npm/parseurl@%401.3.3",
-        "pkg:npm/statuses@%402.0.1",
-        "pkg:npm/unpipe@%401.0.0"
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/encodeurl@2.0.0",
+        "pkg:npm/escape-html@1.0.3",
+        "pkg:npm/on-finished@2.4.1",
+        "pkg:npm/parseurl@1.3.3",
+        "pkg:npm/statuses@2.0.1",
+        "pkg:npm/unpipe@1.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/fresh@%400.5.2",
+      "ref" : "pkg:npm/fresh@0.5.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/http-errors@%402.0.0",
+      "ref" : "pkg:npm/http-errors@2.0.0",
       "dependsOn" : [
-        "pkg:npm/depd@%402.0.0",
-        "pkg:npm/inherits@%402.0.4",
-        "pkg:npm/setprototypeof@%401.2.0",
-        "pkg:npm/statuses@%402.0.1",
-        "pkg:npm/toidentifier@%401.0.1"
+        "pkg:npm/depd@2.0.0",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/setprototypeof@1.2.0",
+        "pkg:npm/statuses@2.0.1",
+        "pkg:npm/toidentifier@1.0.1"
       ]
     },
     {
-      "ref" : "pkg:npm/merge-descriptors@%401.0.3",
+      "ref" : "pkg:npm/merge-descriptors@1.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/methods@%401.1.2",
+      "ref" : "pkg:npm/methods@1.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/on-finished@%402.4.1",
+      "ref" : "pkg:npm/on-finished@2.4.1",
       "dependsOn" : [
-        "pkg:npm/ee-first@%401.1.1"
+        "pkg:npm/ee-first@1.1.1"
       ]
     },
     {
-      "ref" : "pkg:npm/parseurl@%401.3.3",
+      "ref" : "pkg:npm/parseurl@1.3.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/path-to-regexp@%400.1.12",
+      "ref" : "pkg:npm/path-to-regexp@0.1.12",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/proxy-addr@%402.0.7",
+      "ref" : "pkg:npm/proxy-addr@2.0.7",
       "dependsOn" : [
-        "pkg:npm/forwarded@%400.2.0",
-        "pkg:npm/ipaddr.js@%401.9.1"
+        "pkg:npm/forwarded@0.2.0",
+        "pkg:npm/ipaddr.js@1.9.1"
       ]
     },
     {
-      "ref" : "pkg:npm/qs@%406.13.0",
+      "ref" : "pkg:npm/qs@6.13.0",
       "dependsOn" : [
-        "pkg:npm/side-channel@%401.1.0"
+        "pkg:npm/side-channel@1.1.0"
       ]
     },
     {
-      "ref" : "pkg:npm/range-parser@%401.2.1",
+      "ref" : "pkg:npm/range-parser@1.2.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/safe-buffer@%405.2.1",
+      "ref" : "pkg:npm/safe-buffer@5.2.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/send@%400.19.0",
+      "ref" : "pkg:npm/send@0.19.0",
       "dependsOn" : [
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/depd@%402.0.0",
-        "pkg:npm/destroy@%401.2.0",
-        "pkg:npm/encodeurl@%402.0.0",
-        "pkg:npm/escape-html@%401.0.3",
-        "pkg:npm/etag@%401.8.1",
-        "pkg:npm/fresh@%400.5.2",
-        "pkg:npm/http-errors@%402.0.0",
-        "pkg:npm/mime@%401.6.0",
-        "pkg:npm/ms@%402.1.3",
-        "pkg:npm/on-finished@%402.4.1",
-        "pkg:npm/range-parser@%401.2.1",
-        "pkg:npm/statuses@%402.0.1",
-        "pkg:npm/encodeurl@%401.0.2"
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/depd@2.0.0",
+        "pkg:npm/destroy@1.2.0",
+        "pkg:npm/encodeurl@2.0.0",
+        "pkg:npm/escape-html@1.0.3",
+        "pkg:npm/etag@1.8.1",
+        "pkg:npm/fresh@0.5.2",
+        "pkg:npm/http-errors@2.0.0",
+        "pkg:npm/mime@1.6.0",
+        "pkg:npm/ms@2.1.3",
+        "pkg:npm/on-finished@2.4.1",
+        "pkg:npm/range-parser@1.2.1",
+        "pkg:npm/statuses@2.0.1",
+        "pkg:npm/encodeurl@1.0.2"
       ]
     },
     {
-      "ref" : "pkg:npm/serve-static@%401.16.2",
+      "ref" : "pkg:npm/serve-static@1.16.2",
       "dependsOn" : [
-        "pkg:npm/encodeurl@%402.0.0",
-        "pkg:npm/escape-html@%401.0.3",
-        "pkg:npm/parseurl@%401.3.3",
-        "pkg:npm/send@%400.19.0"
+        "pkg:npm/encodeurl@2.0.0",
+        "pkg:npm/escape-html@1.0.3",
+        "pkg:npm/parseurl@1.3.3",
+        "pkg:npm/send@0.19.0"
       ]
     },
     {
-      "ref" : "pkg:npm/setprototypeof@%401.2.0",
+      "ref" : "pkg:npm/setprototypeof@1.2.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/statuses@%402.0.1",
+      "ref" : "pkg:npm/statuses@2.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/type-is@%401.6.18",
+      "ref" : "pkg:npm/type-is@1.6.18",
       "dependsOn" : [
-        "pkg:npm/media-typer@%400.3.0",
-        "pkg:npm/mime-types@%402.1.35"
+        "pkg:npm/media-typer@0.3.0",
+        "pkg:npm/mime-types@2.1.35"
       ]
     },
     {
-      "ref" : "pkg:npm/utils-merge@%401.0.1",
+      "ref" : "pkg:npm/utils-merge@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/vary@%401.1.2",
+      "ref" : "pkg:npm/vary@1.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/jws@%403.2.2",
+      "ref" : "pkg:npm/jws@3.2.2",
       "dependsOn" : [
-        "pkg:npm/jwa@%401.4.1",
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/jwa@1.4.1",
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/lodash.includes@%404.3.0",
+      "ref" : "pkg:npm/lodash.includes@4.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isboolean@%403.0.3",
+      "ref" : "pkg:npm/lodash.isboolean@3.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isinteger@%404.0.4",
+      "ref" : "pkg:npm/lodash.isinteger@4.0.4",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isnumber@%403.0.3",
+      "ref" : "pkg:npm/lodash.isnumber@3.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isplainobject@%404.0.6",
+      "ref" : "pkg:npm/lodash.isplainobject@4.0.6",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isstring@%404.0.1",
+      "ref" : "pkg:npm/lodash.isstring@4.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.once@%404.1.1",
+      "ref" : "pkg:npm/lodash.once@4.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/semver@%405.7.2",
+      "ref" : "pkg:npm/semver@5.7.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40types/bson@%404.0.5",
+      "ref" : "pkg:npm/%40types/bson@4.0.5",
       "dependsOn" : [
-        "pkg:npm/%40types/node@%4022.14.1"
+        "pkg:npm/%40types/node@22.14.1"
       ]
     },
     {
-      "ref" : "pkg:npm/%40types/mongodb@%403.6.20",
+      "ref" : "pkg:npm/%40types/mongodb@3.6.20",
       "dependsOn" : [
-        "pkg:npm/%40types/bson@%404.0.5",
-        "pkg:npm/%40types/node@%4022.14.1",
-        "pkg:npm/%40types/bson@%404.2.4",
-        "pkg:npm/bson@%406.10.3"
+        "pkg:npm/%40types/bson@4.0.5",
+        "pkg:npm/%40types/node@22.14.1",
+        "pkg:npm/%40types/bson@4.2.4",
+        "pkg:npm/bson@6.10.3"
       ]
     },
     {
-      "ref" : "pkg:npm/bson@%401.1.6",
+      "ref" : "pkg:npm/bson@1.1.6",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/kareem@%402.3.2",
+      "ref" : "pkg:npm/kareem@2.3.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/mongodb@%403.7.4",
+      "ref" : "pkg:npm/mongodb@3.7.4",
       "dependsOn" : [
-        "pkg:npm/bl@%402.2.1",
-        "pkg:npm/bson@%401.1.6",
-        "pkg:npm/denque@%401.5.1",
-        "pkg:npm/optional-require@%401.0.3",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/saslprep@%401.0.3",
-        "pkg:npm/optional-require@%401.1.8"
+        "pkg:npm/bl@2.2.1",
+        "pkg:npm/bson@1.1.6",
+        "pkg:npm/denque@1.5.1",
+        "pkg:npm/optional-require@1.0.3",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/saslprep@1.0.3",
+        "pkg:npm/optional-require@1.1.8"
       ]
     },
     {
-      "ref" : "pkg:npm/mongoose-legacy-pluralize@%401.0.2",
+      "ref" : "pkg:npm/mongoose-legacy-pluralize@1.0.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/mpath@%400.8.4",
+      "ref" : "pkg:npm/mpath@0.8.4",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/mquery@%403.2.5",
+      "ref" : "pkg:npm/mquery@3.2.5",
       "dependsOn" : [
-        "pkg:npm/bluebird@%403.5.1",
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/regexp-clone@%401.0.0",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/sliced@%401.0.1",
-        "pkg:npm/debug@%403.1.0",
-        "pkg:npm/safe-buffer@%405.1.2",
-        "pkg:npm/ms@%402.0.0"
+        "pkg:npm/bluebird@3.5.1",
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/regexp-clone@1.0.0",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/sliced@1.0.1",
+        "pkg:npm/debug@3.1.0",
+        "pkg:npm/safe-buffer@5.1.2",
+        "pkg:npm/ms@2.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/optional-require@%401.0.3",
+      "ref" : "pkg:npm/optional-require@1.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/regexp-clone@%401.0.0",
+      "ref" : "pkg:npm/regexp-clone@1.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/sift@%4013.5.2",
+      "ref" : "pkg:npm/sift@13.5.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/sliced@%401.0.1",
+      "ref" : "pkg:npm/sliced@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ms@%402.1.2",
+      "ref" : "pkg:npm/ms@2.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/chokidar@%403.6.0",
+      "ref" : "pkg:npm/chokidar@3.6.0",
       "dependsOn" : [
-        "pkg:npm/anymatch@%403.1.3",
-        "pkg:npm/braces@%403.0.3",
-        "pkg:npm/glob-parent@%405.1.2",
-        "pkg:npm/is-binary-path@%402.1.0",
-        "pkg:npm/is-glob@%404.0.3",
-        "pkg:npm/normalize-path@%403.0.0",
-        "pkg:npm/readdirp@%403.6.0",
-        "pkg:npm/fsevents@%402.3.3"
+        "pkg:npm/anymatch@3.1.3",
+        "pkg:npm/braces@3.0.3",
+        "pkg:npm/glob-parent@5.1.2",
+        "pkg:npm/is-binary-path@2.1.0",
+        "pkg:npm/is-glob@4.0.3",
+        "pkg:npm/normalize-path@3.0.0",
+        "pkg:npm/readdirp@3.6.0",
+        "pkg:npm/fsevents@2.3.3"
       ]
     },
     {
-      "ref" : "pkg:npm/ignore-by-default@%401.0.1",
+      "ref" : "pkg:npm/ignore-by-default@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/minimatch@%403.1.2",
+      "ref" : "pkg:npm/minimatch@3.1.2",
       "dependsOn" : [
-        "pkg:npm/brace-expansion@%401.1.11"
+        "pkg:npm/brace-expansion@1.1.11"
       ]
     },
     {
-      "ref" : "pkg:npm/pstree.remy@%401.1.8",
+      "ref" : "pkg:npm/pstree.remy@1.1.8",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/simple-update-notifier@%401.1.0",
+      "ref" : "pkg:npm/simple-update-notifier@1.1.0",
       "dependsOn" : [
-        "pkg:npm/semver@%405.7.2",
-        "pkg:npm/semver@%407.0.0"
+        "pkg:npm/semver@5.7.2",
+        "pkg:npm/semver@7.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/supports-color@%405.5.0",
+      "ref" : "pkg:npm/supports-color@5.5.0",
       "dependsOn" : [
-        "pkg:npm/has-flag@%403.0.0"
+        "pkg:npm/has-flag@3.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/touch@%403.1.1",
+      "ref" : "pkg:npm/touch@3.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/undefsafe@%402.0.5",
+      "ref" : "pkg:npm/undefsafe@2.0.5",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/debug@%403.2.7",
+      "ref" : "pkg:npm/debug@3.2.7",
       "dependsOn" : [
-        "pkg:npm/ms@%402.1.3"
+        "pkg:npm/ms@2.1.3"
       ]
     },
     {
-      "ref" : "pkg:npm/follow-redirects@%401.5.10",
+      "ref" : "pkg:npm/follow-redirects@1.5.10",
       "dependsOn" : [
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/debug@%403.1.0",
-        "pkg:npm/ms@%402.0.0"
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/debug@3.1.0",
+        "pkg:npm/ms@2.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/%40types/node@%4022.14.1",
+      "ref" : "pkg:npm/%40types/node@22.14.1",
       "dependsOn" : [
-        "pkg:npm/undici-types@%406.21.0"
+        "pkg:npm/undici-types@6.21.0"
       ]
     },
     {
-      "ref" : "pkg:npm/%40types/bson@%404.2.4",
+      "ref" : "pkg:npm/%40types/bson@4.2.4",
       "dependsOn" : [
-        "pkg:npm/bson@%401.1.6"
+        "pkg:npm/bson@1.1.6"
       ]
     },
     {
-      "ref" : "pkg:npm/bson@%406.10.3",
+      "ref" : "pkg:npm/bson@6.10.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/mime-types@%402.1.35",
+      "ref" : "pkg:npm/mime-types@2.1.35",
       "dependsOn" : [
-        "pkg:npm/mime-db@%401.52.0"
+        "pkg:npm/mime-db@1.52.0"
       ]
     },
     {
-      "ref" : "pkg:npm/negotiator@%400.6.3",
+      "ref" : "pkg:npm/negotiator@0.6.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/bytes@%403.1.2",
+      "ref" : "pkg:npm/bytes@3.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/destroy@%401.2.0",
+      "ref" : "pkg:npm/destroy@1.2.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/iconv-lite@%400.4.24",
+      "ref" : "pkg:npm/iconv-lite@0.4.24",
       "dependsOn" : [
-        "pkg:npm/safer-buffer@%402.1.2"
+        "pkg:npm/safer-buffer@2.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/raw-body@%402.5.2",
+      "ref" : "pkg:npm/raw-body@2.5.2",
       "dependsOn" : [
-        "pkg:npm/bytes@%403.1.2",
-        "pkg:npm/http-errors@%402.0.0",
-        "pkg:npm/iconv-lite@%400.4.24",
-        "pkg:npm/unpipe@%401.0.0"
+        "pkg:npm/bytes@3.1.2",
+        "pkg:npm/http-errors@2.0.0",
+        "pkg:npm/iconv-lite@0.4.24",
+        "pkg:npm/unpipe@1.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/unpipe@%401.0.0",
+      "ref" : "pkg:npm/unpipe@1.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/anymatch@%403.1.3",
+      "ref" : "pkg:npm/anymatch@3.1.3",
       "dependsOn" : [
-        "pkg:npm/normalize-path@%403.0.0",
-        "pkg:npm/picomatch@%402.3.1"
+        "pkg:npm/normalize-path@3.0.0",
+        "pkg:npm/picomatch@2.3.1"
       ]
     },
     {
-      "ref" : "pkg:npm/braces@%403.0.3",
+      "ref" : "pkg:npm/braces@3.0.3",
       "dependsOn" : [
-        "pkg:npm/fill-range@%407.1.1"
+        "pkg:npm/fill-range@7.1.1"
       ]
     },
     {
-      "ref" : "pkg:npm/glob-parent@%405.1.2",
+      "ref" : "pkg:npm/glob-parent@5.1.2",
       "dependsOn" : [
-        "pkg:npm/is-glob@%404.0.3"
+        "pkg:npm/is-glob@4.0.3"
       ]
     },
     {
-      "ref" : "pkg:npm/is-binary-path@%402.1.0",
+      "ref" : "pkg:npm/is-binary-path@2.1.0",
       "dependsOn" : [
-        "pkg:npm/binary-extensions@%402.3.0"
+        "pkg:npm/binary-extensions@2.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/is-glob@%404.0.3",
+      "ref" : "pkg:npm/is-glob@4.0.3",
       "dependsOn" : [
-        "pkg:npm/is-extglob@%402.1.1"
+        "pkg:npm/is-extglob@2.1.1"
       ]
     },
     {
-      "ref" : "pkg:npm/normalize-path@%403.0.0",
+      "ref" : "pkg:npm/normalize-path@3.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/readdirp@%403.6.0",
+      "ref" : "pkg:npm/readdirp@3.6.0",
       "dependsOn" : [
-        "pkg:npm/picomatch@%402.3.1"
+        "pkg:npm/picomatch@2.3.1"
       ]
     },
     {
-      "ref" : "pkg:npm/fsevents@%402.3.3",
+      "ref" : "pkg:npm/fsevents@2.3.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/debug@%403.1.0",
+      "ref" : "pkg:npm/debug@3.1.0",
       "dependsOn" : [
-        "pkg:npm/ms@%402.1.3"
+        "pkg:npm/ms@2.1.3"
       ]
     },
     {
-      "ref" : "pkg:npm/inherits@%402.0.4",
+      "ref" : "pkg:npm/inherits@2.0.4",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/toidentifier@%401.0.1",
+      "ref" : "pkg:npm/toidentifier@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/jwa@%401.4.1",
+      "ref" : "pkg:npm/jwa@1.4.1",
       "dependsOn" : [
-        "pkg:npm/buffer-equal-constant-time@%401.0.1",
-        "pkg:npm/ecdsa-sig-formatter@%401.0.11",
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/buffer-equal-constant-time@1.0.1",
+        "pkg:npm/ecdsa-sig-formatter@1.0.11",
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/brace-expansion@%401.1.11",
+      "ref" : "pkg:npm/brace-expansion@1.1.11",
       "dependsOn" : [
-        "pkg:npm/balanced-match@%401.0.2",
-        "pkg:npm/concat-map@%400.0.1"
+        "pkg:npm/balanced-match@1.0.2",
+        "pkg:npm/concat-map@0.0.1"
       ]
     },
     {
-      "ref" : "pkg:npm/bl@%402.2.1",
+      "ref" : "pkg:npm/bl@2.2.1",
       "dependsOn" : [
-        "pkg:npm/readable-stream@%402.3.8",
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/readable-stream@2.3.8",
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/denque@%401.5.1",
+      "ref" : "pkg:npm/denque@1.5.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/saslprep@%401.0.3",
+      "ref" : "pkg:npm/saslprep@1.0.3",
       "dependsOn" : [
-        "pkg:npm/sparse-bitfield@%403.0.3"
+        "pkg:npm/sparse-bitfield@3.0.3"
       ]
     },
     {
-      "ref" : "pkg:npm/optional-require@%401.1.8",
+      "ref" : "pkg:npm/optional-require@1.1.8",
       "dependsOn" : [
-        "pkg:npm/require-at@%401.0.6"
+        "pkg:npm/require-at@1.0.6"
       ]
     },
     {
-      "ref" : "pkg:npm/require-at@%401.0.6",
+      "ref" : "pkg:npm/require-at@1.0.6",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/bluebird@%403.5.1",
+      "ref" : "pkg:npm/bluebird@3.5.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/safe-buffer@%405.1.2",
+      "ref" : "pkg:npm/safe-buffer@5.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ee-first@%401.1.1",
+      "ref" : "pkg:npm/ee-first@1.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/forwarded@%400.2.0",
+      "ref" : "pkg:npm/forwarded@0.2.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ipaddr.js@%401.9.1",
+      "ref" : "pkg:npm/ipaddr.js@1.9.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/side-channel@%401.1.0",
+      "ref" : "pkg:npm/side-channel@1.1.0",
       "dependsOn" : [
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/object-inspect@%401.13.4",
-        "pkg:npm/side-channel-list@%401.0.0",
-        "pkg:npm/side-channel-map@%401.0.1",
-        "pkg:npm/side-channel-weakmap@%401.0.2"
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/object-inspect@1.13.4",
+        "pkg:npm/side-channel-list@1.0.0",
+        "pkg:npm/side-channel-map@1.0.1",
+        "pkg:npm/side-channel-weakmap@1.0.2"
       ]
     },
     {
-      "ref" : "pkg:npm/mime@%401.6.0",
+      "ref" : "pkg:npm/mime@1.6.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/encodeurl@%401.0.2",
+      "ref" : "pkg:npm/encodeurl@1.0.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/semver@%407.0.0",
+      "ref" : "pkg:npm/semver@7.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/has-flag@%403.0.0",
+      "ref" : "pkg:npm/has-flag@3.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/media-typer@%400.3.0",
+      "ref" : "pkg:npm/media-typer@0.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/undici-types@%406.21.0",
+      "ref" : "pkg:npm/undici-types@6.21.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/picomatch@%402.3.1",
+      "ref" : "pkg:npm/picomatch@2.3.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/readable-stream@%402.3.8",
+      "ref" : "pkg:npm/readable-stream@2.3.8",
       "dependsOn" : [
-        "pkg:npm/core-util-is@%401.0.3",
-        "pkg:npm/inherits@%402.0.4",
-        "pkg:npm/isarray@%401.0.0",
-        "pkg:npm/process-nextick-args@%402.0.1",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/string_decoder@%401.1.1",
-        "pkg:npm/util-deprecate@%401.0.2",
-        "pkg:npm/safe-buffer@%405.1.2"
+        "pkg:npm/core-util-is@1.0.3",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/isarray@1.0.0",
+        "pkg:npm/process-nextick-args@2.0.1",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/string_decoder@1.1.1",
+        "pkg:npm/util-deprecate@1.0.2",
+        "pkg:npm/safe-buffer@5.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/balanced-match@%401.0.2",
+      "ref" : "pkg:npm/balanced-match@1.0.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/concat-map@%400.0.1",
+      "ref" : "pkg:npm/concat-map@0.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/fill-range@%407.1.1",
+      "ref" : "pkg:npm/fill-range@7.1.1",
       "dependsOn" : [
-        "pkg:npm/to-regex-range@%405.0.1"
+        "pkg:npm/to-regex-range@5.0.1"
       ]
     },
     {
-      "ref" : "pkg:npm/safer-buffer@%402.1.2",
+      "ref" : "pkg:npm/safer-buffer@2.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/binary-extensions@%402.3.0",
+      "ref" : "pkg:npm/binary-extensions@2.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/is-extglob@%402.1.1",
+      "ref" : "pkg:npm/is-extglob@2.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/buffer-equal-constant-time@%401.0.1",
+      "ref" : "pkg:npm/buffer-equal-constant-time@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ecdsa-sig-formatter@%401.0.11",
+      "ref" : "pkg:npm/ecdsa-sig-formatter@1.0.11",
       "dependsOn" : [
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/mime-db@%401.52.0",
+      "ref" : "pkg:npm/mime-db@1.52.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/sparse-bitfield@%403.0.3",
+      "ref" : "pkg:npm/sparse-bitfield@3.0.3",
       "dependsOn" : [
-        "pkg:npm/memory-pager@%401.5.0"
+        "pkg:npm/memory-pager@1.5.0"
       ]
     },
     {
-      "ref" : "pkg:npm/es-errors@%401.3.0",
+      "ref" : "pkg:npm/es-errors@1.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/object-inspect@%401.13.4",
+      "ref" : "pkg:npm/object-inspect@1.13.4",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/side-channel-list@%401.0.0",
+      "ref" : "pkg:npm/side-channel-list@1.0.0",
       "dependsOn" : [
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/object-inspect@%401.13.4"
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/object-inspect@1.13.4"
       ]
     },
     {
-      "ref" : "pkg:npm/side-channel-map@%401.0.1",
+      "ref" : "pkg:npm/side-channel-map@1.0.1",
       "dependsOn" : [
-        "pkg:npm/call-bound@%401.0.4",
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/get-intrinsic@%401.3.0",
-        "pkg:npm/object-inspect@%401.13.4"
+        "pkg:npm/call-bound@1.0.4",
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/get-intrinsic@1.3.0",
+        "pkg:npm/object-inspect@1.13.4"
       ]
     },
     {
-      "ref" : "pkg:npm/side-channel-weakmap@%401.0.2",
+      "ref" : "pkg:npm/side-channel-weakmap@1.0.2",
       "dependsOn" : [
-        "pkg:npm/call-bound@%401.0.4",
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/get-intrinsic@%401.3.0",
-        "pkg:npm/object-inspect@%401.13.4",
-        "pkg:npm/side-channel-map@%401.0.1"
+        "pkg:npm/call-bound@1.0.4",
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/get-intrinsic@1.3.0",
+        "pkg:npm/object-inspect@1.13.4",
+        "pkg:npm/side-channel-map@1.0.1"
       ]
     },
     {
-      "ref" : "pkg:npm/to-regex-range@%405.0.1",
+      "ref" : "pkg:npm/to-regex-range@5.0.1",
       "dependsOn" : [
-        "pkg:npm/is-number@%407.0.0"
+        "pkg:npm/is-number@7.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/core-util-is@%401.0.3",
+      "ref" : "pkg:npm/core-util-is@1.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/isarray@%401.0.0",
+      "ref" : "pkg:npm/isarray@1.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/process-nextick-args@%402.0.1",
+      "ref" : "pkg:npm/process-nextick-args@2.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/string_decoder@%401.1.1",
+      "ref" : "pkg:npm/string_decoder@1.1.1",
       "dependsOn" : [
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/safe-buffer@%405.1.2"
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/safe-buffer@5.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/util-deprecate@%401.0.2",
+      "ref" : "pkg:npm/util-deprecate@1.0.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/call-bound@%401.0.4",
+      "ref" : "pkg:npm/call-bound@1.0.4",
       "dependsOn" : [
-        "pkg:npm/call-bind-apply-helpers@%401.0.2",
-        "pkg:npm/get-intrinsic@%401.3.0"
+        "pkg:npm/call-bind-apply-helpers@1.0.2",
+        "pkg:npm/get-intrinsic@1.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/get-intrinsic@%401.3.0",
+      "ref" : "pkg:npm/get-intrinsic@1.3.0",
       "dependsOn" : [
-        "pkg:npm/call-bind-apply-helpers@%401.0.2",
-        "pkg:npm/es-define-property@%401.0.1",
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/es-object-atoms@%401.1.1",
-        "pkg:npm/function-bind@%401.1.2",
-        "pkg:npm/get-proto@%401.0.1",
-        "pkg:npm/gopd@%401.2.0",
-        "pkg:npm/has-symbols@%401.1.0",
-        "pkg:npm/hasown@%402.0.2",
-        "pkg:npm/math-intrinsics@%401.1.0"
+        "pkg:npm/call-bind-apply-helpers@1.0.2",
+        "pkg:npm/es-define-property@1.0.1",
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/es-object-atoms@1.1.1",
+        "pkg:npm/function-bind@1.1.2",
+        "pkg:npm/get-proto@1.0.1",
+        "pkg:npm/gopd@1.2.0",
+        "pkg:npm/has-symbols@1.1.0",
+        "pkg:npm/hasown@2.0.2",
+        "pkg:npm/math-intrinsics@1.1.0"
       ]
     },
     {
-      "ref" : "pkg:npm/memory-pager@%401.5.0",
+      "ref" : "pkg:npm/memory-pager@1.5.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/call-bind-apply-helpers@%401.0.2",
+      "ref" : "pkg:npm/call-bind-apply-helpers@1.0.2",
       "dependsOn" : [
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/function-bind@%401.1.2"
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/function-bind@1.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/es-define-property@%401.0.1",
+      "ref" : "pkg:npm/es-define-property@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/es-object-atoms@%401.1.1",
+      "ref" : "pkg:npm/es-object-atoms@1.1.1",
       "dependsOn" : [
-        "pkg:npm/es-errors@%401.3.0"
+        "pkg:npm/es-errors@1.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/function-bind@%401.1.2",
+      "ref" : "pkg:npm/function-bind@1.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/get-proto@%401.0.1",
+      "ref" : "pkg:npm/get-proto@1.0.1",
       "dependsOn" : [
-        "pkg:npm/dunder-proto@%401.0.1",
-        "pkg:npm/es-object-atoms@%401.1.1"
+        "pkg:npm/dunder-proto@1.0.1",
+        "pkg:npm/es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref" : "pkg:npm/gopd@%401.2.0",
+      "ref" : "pkg:npm/gopd@1.2.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/has-symbols@%401.1.0",
+      "ref" : "pkg:npm/has-symbols@1.1.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/hasown@%402.0.2",
+      "ref" : "pkg:npm/hasown@2.0.2",
       "dependsOn" : [
-        "pkg:npm/function-bind@%401.1.2"
+        "pkg:npm/function-bind@1.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/math-intrinsics@%401.1.0",
+      "ref" : "pkg:npm/math-intrinsics@1.1.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/is-number@%407.0.0",
+      "ref" : "pkg:npm/is-number@7.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/dunder-proto@%401.0.1",
+      "ref" : "pkg:npm/dunder-proto@1.0.1",
       "dependsOn" : [
-        "pkg:npm/call-bind-apply-helpers@%401.0.2",
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/gopd@%401.2.0"
+        "pkg:npm/call-bind-apply-helpers@1.0.2",
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/gopd@1.2.0"
       ]
     }
   ]

--- a/test/providers/tst_manifests/yarn-classic/package_json_deps_without_exhortignore_object/stack_expected_sbom.json
+++ b/test/providers/tst_manifests/yarn-classic/package_json_deps_without_exhortignore_object/stack_expected_sbom.json
@@ -22,2051 +22,2051 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/joi@%4017.1.1",
+      "bom-ref" : "pkg:npm/%40hapi/joi@17.1.1",
       "group" : "@hapi",
       "name" : "joi",
-      "version" : "@17.1.1",
-      "purl" : "pkg:npm/%40hapi/joi@%4017.1.1"
+      "version" : "17.1.1",
+      "purl" : "pkg:npm/%40hapi/joi@17.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/backend@%400.0.0",
+      "bom-ref" : "pkg:npm/backend@0.0.0",
       "name" : "backend",
-      "version" : "@0.0.0",
-      "purl" : "pkg:npm/backend@%400.0.0"
+      "version" : "0.0.0",
+      "purl" : "pkg:npm/backend@0.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bcryptjs@%402.4.3",
+      "bom-ref" : "pkg:npm/bcryptjs@2.4.3",
       "name" : "bcryptjs",
-      "version" : "@2.4.3",
-      "purl" : "pkg:npm/bcryptjs@%402.4.3"
+      "version" : "2.4.3",
+      "purl" : "pkg:npm/bcryptjs@2.4.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/dotenv@%408.6.0",
+      "bom-ref" : "pkg:npm/dotenv@8.6.0",
       "name" : "dotenv",
-      "version" : "@8.6.0",
-      "purl" : "pkg:npm/dotenv@%408.6.0"
+      "version" : "8.6.0",
+      "purl" : "pkg:npm/dotenv@8.6.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/express@%404.21.2",
+      "bom-ref" : "pkg:npm/express@4.21.2",
       "name" : "express",
-      "version" : "@4.21.2",
-      "purl" : "pkg:npm/express@%404.21.2"
+      "version" : "4.21.2",
+      "purl" : "pkg:npm/express@4.21.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/jsonwebtoken@%408.5.1",
+      "bom-ref" : "pkg:npm/jsonwebtoken@8.5.1",
       "name" : "jsonwebtoken",
-      "version" : "@8.5.1",
-      "purl" : "pkg:npm/jsonwebtoken@%408.5.1"
+      "version" : "8.5.1",
+      "purl" : "pkg:npm/jsonwebtoken@8.5.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mongoose@%405.13.23",
+      "bom-ref" : "pkg:npm/mongoose@5.13.23",
       "name" : "mongoose",
-      "version" : "@5.13.23",
-      "purl" : "pkg:npm/mongoose@%405.13.23"
+      "version" : "5.13.23",
+      "purl" : "pkg:npm/mongoose@5.13.23"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/nodemon@%402.0.22",
+      "bom-ref" : "pkg:npm/nodemon@2.0.22",
       "name" : "nodemon",
-      "version" : "@2.0.22",
-      "purl" : "pkg:npm/nodemon@%402.0.22"
+      "version" : "2.0.22",
+      "purl" : "pkg:npm/nodemon@2.0.22"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/axios@%400.19.2",
+      "bom-ref" : "pkg:npm/axios@0.19.2",
       "name" : "axios",
-      "version" : "@0.19.2",
-      "purl" : "pkg:npm/axios@%400.19.2"
+      "version" : "0.19.2",
+      "purl" : "pkg:npm/axios@0.19.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/debug@%402.6.9",
+      "bom-ref" : "pkg:npm/debug@2.6.9",
       "name" : "debug",
-      "version" : "@2.6.9",
-      "purl" : "pkg:npm/debug@%402.6.9"
+      "version" : "2.6.9",
+      "purl" : "pkg:npm/debug@2.6.9"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ms@%402.1.3",
+      "bom-ref" : "pkg:npm/ms@2.1.3",
       "name" : "ms",
-      "version" : "@2.1.3",
-      "purl" : "pkg:npm/ms@%402.1.3"
+      "version" : "2.1.3",
+      "purl" : "pkg:npm/ms@2.1.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ms@%402.0.0",
+      "bom-ref" : "pkg:npm/ms@2.0.0",
       "name" : "ms",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/ms@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/ms@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/address@%404.1.0",
+      "bom-ref" : "pkg:npm/%40hapi/address@4.1.0",
       "group" : "@hapi",
       "name" : "address",
-      "version" : "@4.1.0",
-      "purl" : "pkg:npm/%40hapi/address@%404.1.0"
+      "version" : "4.1.0",
+      "purl" : "pkg:npm/%40hapi/address@4.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/formula@%402.0.0",
+      "bom-ref" : "pkg:npm/%40hapi/formula@2.0.0",
       "group" : "@hapi",
       "name" : "formula",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/%40hapi/formula@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/%40hapi/formula@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/hoek@%409.3.0",
+      "bom-ref" : "pkg:npm/%40hapi/hoek@9.3.0",
       "group" : "@hapi",
       "name" : "hoek",
-      "version" : "@9.3.0",
-      "purl" : "pkg:npm/%40hapi/hoek@%409.3.0"
+      "version" : "9.3.0",
+      "purl" : "pkg:npm/%40hapi/hoek@9.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/pinpoint@%402.0.1",
+      "bom-ref" : "pkg:npm/%40hapi/pinpoint@2.0.1",
       "group" : "@hapi",
       "name" : "pinpoint",
-      "version" : "@2.0.1",
-      "purl" : "pkg:npm/%40hapi/pinpoint@%402.0.1"
+      "version" : "2.0.1",
+      "purl" : "pkg:npm/%40hapi/pinpoint@2.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40hapi/topo@%405.1.0",
+      "bom-ref" : "pkg:npm/%40hapi/topo@5.1.0",
       "group" : "@hapi",
       "name" : "topo",
-      "version" : "@5.1.0",
-      "purl" : "pkg:npm/%40hapi/topo@%405.1.0"
+      "version" : "5.1.0",
+      "purl" : "pkg:npm/%40hapi/topo@5.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/accepts@%401.3.8",
+      "bom-ref" : "pkg:npm/accepts@1.3.8",
       "name" : "accepts",
-      "version" : "@1.3.8",
-      "purl" : "pkg:npm/accepts@%401.3.8"
+      "version" : "1.3.8",
+      "purl" : "pkg:npm/accepts@1.3.8"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/array-flatten@%401.1.1",
+      "bom-ref" : "pkg:npm/array-flatten@1.1.1",
       "name" : "array-flatten",
-      "version" : "@1.1.1",
-      "purl" : "pkg:npm/array-flatten@%401.1.1"
+      "version" : "1.1.1",
+      "purl" : "pkg:npm/array-flatten@1.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/body-parser@%401.20.3",
+      "bom-ref" : "pkg:npm/body-parser@1.20.3",
       "name" : "body-parser",
-      "version" : "@1.20.3",
-      "purl" : "pkg:npm/body-parser@%401.20.3"
+      "version" : "1.20.3",
+      "purl" : "pkg:npm/body-parser@1.20.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/content-disposition@%400.5.4",
+      "bom-ref" : "pkg:npm/content-disposition@0.5.4",
       "name" : "content-disposition",
-      "version" : "@0.5.4",
-      "purl" : "pkg:npm/content-disposition@%400.5.4"
+      "version" : "0.5.4",
+      "purl" : "pkg:npm/content-disposition@0.5.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/content-type@%401.0.5",
+      "bom-ref" : "pkg:npm/content-type@1.0.5",
       "name" : "content-type",
-      "version" : "@1.0.5",
-      "purl" : "pkg:npm/content-type@%401.0.5"
+      "version" : "1.0.5",
+      "purl" : "pkg:npm/content-type@1.0.5"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/cookie@%400.7.1",
+      "bom-ref" : "pkg:npm/cookie@0.7.1",
       "name" : "cookie",
-      "version" : "@0.7.1",
-      "purl" : "pkg:npm/cookie@%400.7.1"
+      "version" : "0.7.1",
+      "purl" : "pkg:npm/cookie@0.7.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/cookie-signature@%401.0.6",
+      "bom-ref" : "pkg:npm/cookie-signature@1.0.6",
       "name" : "cookie-signature",
-      "version" : "@1.0.6",
-      "purl" : "pkg:npm/cookie-signature@%401.0.6"
+      "version" : "1.0.6",
+      "purl" : "pkg:npm/cookie-signature@1.0.6"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/depd@%402.0.0",
+      "bom-ref" : "pkg:npm/depd@2.0.0",
       "name" : "depd",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/depd@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/depd@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/encodeurl@%402.0.0",
+      "bom-ref" : "pkg:npm/encodeurl@2.0.0",
       "name" : "encodeurl",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/encodeurl@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/encodeurl@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/escape-html@%401.0.3",
+      "bom-ref" : "pkg:npm/escape-html@1.0.3",
       "name" : "escape-html",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/escape-html@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/escape-html@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/etag@%401.8.1",
+      "bom-ref" : "pkg:npm/etag@1.8.1",
       "name" : "etag",
-      "version" : "@1.8.1",
-      "purl" : "pkg:npm/etag@%401.8.1"
+      "version" : "1.8.1",
+      "purl" : "pkg:npm/etag@1.8.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/finalhandler@%401.3.1",
+      "bom-ref" : "pkg:npm/finalhandler@1.3.1",
       "name" : "finalhandler",
-      "version" : "@1.3.1",
-      "purl" : "pkg:npm/finalhandler@%401.3.1"
+      "version" : "1.3.1",
+      "purl" : "pkg:npm/finalhandler@1.3.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/fresh@%400.5.2",
+      "bom-ref" : "pkg:npm/fresh@0.5.2",
       "name" : "fresh",
-      "version" : "@0.5.2",
-      "purl" : "pkg:npm/fresh@%400.5.2"
+      "version" : "0.5.2",
+      "purl" : "pkg:npm/fresh@0.5.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/http-errors@%402.0.0",
+      "bom-ref" : "pkg:npm/http-errors@2.0.0",
       "name" : "http-errors",
-      "version" : "@2.0.0",
-      "purl" : "pkg:npm/http-errors@%402.0.0"
+      "version" : "2.0.0",
+      "purl" : "pkg:npm/http-errors@2.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/merge-descriptors@%401.0.3",
+      "bom-ref" : "pkg:npm/merge-descriptors@1.0.3",
       "name" : "merge-descriptors",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/merge-descriptors@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/merge-descriptors@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/methods@%401.1.2",
+      "bom-ref" : "pkg:npm/methods@1.1.2",
       "name" : "methods",
-      "version" : "@1.1.2",
-      "purl" : "pkg:npm/methods@%401.1.2"
+      "version" : "1.1.2",
+      "purl" : "pkg:npm/methods@1.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/on-finished@%402.4.1",
+      "bom-ref" : "pkg:npm/on-finished@2.4.1",
       "name" : "on-finished",
-      "version" : "@2.4.1",
-      "purl" : "pkg:npm/on-finished@%402.4.1"
+      "version" : "2.4.1",
+      "purl" : "pkg:npm/on-finished@2.4.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/parseurl@%401.3.3",
+      "bom-ref" : "pkg:npm/parseurl@1.3.3",
       "name" : "parseurl",
-      "version" : "@1.3.3",
-      "purl" : "pkg:npm/parseurl@%401.3.3"
+      "version" : "1.3.3",
+      "purl" : "pkg:npm/parseurl@1.3.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/path-to-regexp@%400.1.12",
+      "bom-ref" : "pkg:npm/path-to-regexp@0.1.12",
       "name" : "path-to-regexp",
-      "version" : "@0.1.12",
-      "purl" : "pkg:npm/path-to-regexp@%400.1.12"
+      "version" : "0.1.12",
+      "purl" : "pkg:npm/path-to-regexp@0.1.12"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/proxy-addr@%402.0.7",
+      "bom-ref" : "pkg:npm/proxy-addr@2.0.7",
       "name" : "proxy-addr",
-      "version" : "@2.0.7",
-      "purl" : "pkg:npm/proxy-addr@%402.0.7"
+      "version" : "2.0.7",
+      "purl" : "pkg:npm/proxy-addr@2.0.7"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/qs@%406.13.0",
+      "bom-ref" : "pkg:npm/qs@6.13.0",
       "name" : "qs",
-      "version" : "@6.13.0",
-      "purl" : "pkg:npm/qs@%406.13.0"
+      "version" : "6.13.0",
+      "purl" : "pkg:npm/qs@6.13.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/range-parser@%401.2.1",
+      "bom-ref" : "pkg:npm/range-parser@1.2.1",
       "name" : "range-parser",
-      "version" : "@1.2.1",
-      "purl" : "pkg:npm/range-parser@%401.2.1"
+      "version" : "1.2.1",
+      "purl" : "pkg:npm/range-parser@1.2.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/safe-buffer@%405.2.1",
+      "bom-ref" : "pkg:npm/safe-buffer@5.2.1",
       "name" : "safe-buffer",
-      "version" : "@5.2.1",
-      "purl" : "pkg:npm/safe-buffer@%405.2.1"
+      "version" : "5.2.1",
+      "purl" : "pkg:npm/safe-buffer@5.2.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/send@%400.19.0",
+      "bom-ref" : "pkg:npm/send@0.19.0",
       "name" : "send",
-      "version" : "@0.19.0",
-      "purl" : "pkg:npm/send@%400.19.0"
+      "version" : "0.19.0",
+      "purl" : "pkg:npm/send@0.19.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/serve-static@%401.16.2",
+      "bom-ref" : "pkg:npm/serve-static@1.16.2",
       "name" : "serve-static",
-      "version" : "@1.16.2",
-      "purl" : "pkg:npm/serve-static@%401.16.2"
+      "version" : "1.16.2",
+      "purl" : "pkg:npm/serve-static@1.16.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/setprototypeof@%401.2.0",
+      "bom-ref" : "pkg:npm/setprototypeof@1.2.0",
       "name" : "setprototypeof",
-      "version" : "@1.2.0",
-      "purl" : "pkg:npm/setprototypeof@%401.2.0"
+      "version" : "1.2.0",
+      "purl" : "pkg:npm/setprototypeof@1.2.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/statuses@%402.0.1",
+      "bom-ref" : "pkg:npm/statuses@2.0.1",
       "name" : "statuses",
-      "version" : "@2.0.1",
-      "purl" : "pkg:npm/statuses@%402.0.1"
+      "version" : "2.0.1",
+      "purl" : "pkg:npm/statuses@2.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/type-is@%401.6.18",
+      "bom-ref" : "pkg:npm/type-is@1.6.18",
       "name" : "type-is",
-      "version" : "@1.6.18",
-      "purl" : "pkg:npm/type-is@%401.6.18"
+      "version" : "1.6.18",
+      "purl" : "pkg:npm/type-is@1.6.18"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/utils-merge@%401.0.1",
+      "bom-ref" : "pkg:npm/utils-merge@1.0.1",
       "name" : "utils-merge",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/utils-merge@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/utils-merge@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/vary@%401.1.2",
+      "bom-ref" : "pkg:npm/vary@1.1.2",
       "name" : "vary",
-      "version" : "@1.1.2",
-      "purl" : "pkg:npm/vary@%401.1.2"
+      "version" : "1.1.2",
+      "purl" : "pkg:npm/vary@1.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/jws@%403.2.2",
+      "bom-ref" : "pkg:npm/jws@3.2.2",
       "name" : "jws",
-      "version" : "@3.2.2",
-      "purl" : "pkg:npm/jws@%403.2.2"
+      "version" : "3.2.2",
+      "purl" : "pkg:npm/jws@3.2.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.includes@%404.3.0",
+      "bom-ref" : "pkg:npm/lodash.includes@4.3.0",
       "name" : "lodash.includes",
-      "version" : "@4.3.0",
-      "purl" : "pkg:npm/lodash.includes@%404.3.0"
+      "version" : "4.3.0",
+      "purl" : "pkg:npm/lodash.includes@4.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isboolean@%403.0.3",
+      "bom-ref" : "pkg:npm/lodash.isboolean@3.0.3",
       "name" : "lodash.isboolean",
-      "version" : "@3.0.3",
-      "purl" : "pkg:npm/lodash.isboolean@%403.0.3"
+      "version" : "3.0.3",
+      "purl" : "pkg:npm/lodash.isboolean@3.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isinteger@%404.0.4",
+      "bom-ref" : "pkg:npm/lodash.isinteger@4.0.4",
       "name" : "lodash.isinteger",
-      "version" : "@4.0.4",
-      "purl" : "pkg:npm/lodash.isinteger@%404.0.4"
+      "version" : "4.0.4",
+      "purl" : "pkg:npm/lodash.isinteger@4.0.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isnumber@%403.0.3",
+      "bom-ref" : "pkg:npm/lodash.isnumber@3.0.3",
       "name" : "lodash.isnumber",
-      "version" : "@3.0.3",
-      "purl" : "pkg:npm/lodash.isnumber@%403.0.3"
+      "version" : "3.0.3",
+      "purl" : "pkg:npm/lodash.isnumber@3.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isplainobject@%404.0.6",
+      "bom-ref" : "pkg:npm/lodash.isplainobject@4.0.6",
       "name" : "lodash.isplainobject",
-      "version" : "@4.0.6",
-      "purl" : "pkg:npm/lodash.isplainobject@%404.0.6"
+      "version" : "4.0.6",
+      "purl" : "pkg:npm/lodash.isplainobject@4.0.6"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.isstring@%404.0.1",
+      "bom-ref" : "pkg:npm/lodash.isstring@4.0.1",
       "name" : "lodash.isstring",
-      "version" : "@4.0.1",
-      "purl" : "pkg:npm/lodash.isstring@%404.0.1"
+      "version" : "4.0.1",
+      "purl" : "pkg:npm/lodash.isstring@4.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/lodash.once@%404.1.1",
+      "bom-ref" : "pkg:npm/lodash.once@4.1.1",
       "name" : "lodash.once",
-      "version" : "@4.1.1",
-      "purl" : "pkg:npm/lodash.once@%404.1.1"
+      "version" : "4.1.1",
+      "purl" : "pkg:npm/lodash.once@4.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/semver@%405.7.2",
+      "bom-ref" : "pkg:npm/semver@5.7.2",
       "name" : "semver",
-      "version" : "@5.7.2",
-      "purl" : "pkg:npm/semver@%405.7.2"
+      "version" : "5.7.2",
+      "purl" : "pkg:npm/semver@5.7.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40types/bson@%404.0.5",
+      "bom-ref" : "pkg:npm/%40types/bson@4.0.5",
       "group" : "@types",
       "name" : "bson",
-      "version" : "@4.0.5",
-      "purl" : "pkg:npm/%40types/bson@%404.0.5"
+      "version" : "4.0.5",
+      "purl" : "pkg:npm/%40types/bson@4.0.5"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40types/mongodb@%403.6.20",
+      "bom-ref" : "pkg:npm/%40types/mongodb@3.6.20",
       "group" : "@types",
       "name" : "mongodb",
-      "version" : "@3.6.20",
-      "purl" : "pkg:npm/%40types/mongodb@%403.6.20"
+      "version" : "3.6.20",
+      "purl" : "pkg:npm/%40types/mongodb@3.6.20"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bson@%401.1.6",
+      "bom-ref" : "pkg:npm/bson@1.1.6",
       "name" : "bson",
-      "version" : "@1.1.6",
-      "purl" : "pkg:npm/bson@%401.1.6"
+      "version" : "1.1.6",
+      "purl" : "pkg:npm/bson@1.1.6"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/kareem@%402.3.2",
+      "bom-ref" : "pkg:npm/kareem@2.3.2",
       "name" : "kareem",
-      "version" : "@2.3.2",
-      "purl" : "pkg:npm/kareem@%402.3.2"
+      "version" : "2.3.2",
+      "purl" : "pkg:npm/kareem@2.3.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mongodb@%403.7.4",
+      "bom-ref" : "pkg:npm/mongodb@3.7.4",
       "name" : "mongodb",
-      "version" : "@3.7.4",
-      "purl" : "pkg:npm/mongodb@%403.7.4"
+      "version" : "3.7.4",
+      "purl" : "pkg:npm/mongodb@3.7.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mongoose-legacy-pluralize@%401.0.2",
+      "bom-ref" : "pkg:npm/mongoose-legacy-pluralize@1.0.2",
       "name" : "mongoose-legacy-pluralize",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/mongoose-legacy-pluralize@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/mongoose-legacy-pluralize@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mpath@%400.8.4",
+      "bom-ref" : "pkg:npm/mpath@0.8.4",
       "name" : "mpath",
-      "version" : "@0.8.4",
-      "purl" : "pkg:npm/mpath@%400.8.4"
+      "version" : "0.8.4",
+      "purl" : "pkg:npm/mpath@0.8.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mquery@%403.2.5",
+      "bom-ref" : "pkg:npm/mquery@3.2.5",
       "name" : "mquery",
-      "version" : "@3.2.5",
-      "purl" : "pkg:npm/mquery@%403.2.5"
+      "version" : "3.2.5",
+      "purl" : "pkg:npm/mquery@3.2.5"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/optional-require@%401.0.3",
+      "bom-ref" : "pkg:npm/optional-require@1.0.3",
       "name" : "optional-require",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/optional-require@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/optional-require@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/regexp-clone@%401.0.0",
+      "bom-ref" : "pkg:npm/regexp-clone@1.0.0",
       "name" : "regexp-clone",
-      "version" : "@1.0.0",
-      "purl" : "pkg:npm/regexp-clone@%401.0.0"
+      "version" : "1.0.0",
+      "purl" : "pkg:npm/regexp-clone@1.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/sift@%4013.5.2",
+      "bom-ref" : "pkg:npm/sift@13.5.2",
       "name" : "sift",
-      "version" : "@13.5.2",
-      "purl" : "pkg:npm/sift@%4013.5.2"
+      "version" : "13.5.2",
+      "purl" : "pkg:npm/sift@13.5.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/sliced@%401.0.1",
+      "bom-ref" : "pkg:npm/sliced@1.0.1",
       "name" : "sliced",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/sliced@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/sliced@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ms@%402.1.2",
+      "bom-ref" : "pkg:npm/ms@2.1.2",
       "name" : "ms",
-      "version" : "@2.1.2",
-      "purl" : "pkg:npm/ms@%402.1.2"
+      "version" : "2.1.2",
+      "purl" : "pkg:npm/ms@2.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/chokidar@%403.6.0",
+      "bom-ref" : "pkg:npm/chokidar@3.6.0",
       "name" : "chokidar",
-      "version" : "@3.6.0",
-      "purl" : "pkg:npm/chokidar@%403.6.0"
+      "version" : "3.6.0",
+      "purl" : "pkg:npm/chokidar@3.6.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ignore-by-default@%401.0.1",
+      "bom-ref" : "pkg:npm/ignore-by-default@1.0.1",
       "name" : "ignore-by-default",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/ignore-by-default@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/ignore-by-default@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/minimatch@%403.1.2",
+      "bom-ref" : "pkg:npm/minimatch@3.1.2",
       "name" : "minimatch",
-      "version" : "@3.1.2",
-      "purl" : "pkg:npm/minimatch@%403.1.2"
+      "version" : "3.1.2",
+      "purl" : "pkg:npm/minimatch@3.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/pstree.remy@%401.1.8",
+      "bom-ref" : "pkg:npm/pstree.remy@1.1.8",
       "name" : "pstree.remy",
-      "version" : "@1.1.8",
-      "purl" : "pkg:npm/pstree.remy@%401.1.8"
+      "version" : "1.1.8",
+      "purl" : "pkg:npm/pstree.remy@1.1.8"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/simple-update-notifier@%401.1.0",
+      "bom-ref" : "pkg:npm/simple-update-notifier@1.1.0",
       "name" : "simple-update-notifier",
-      "version" : "@1.1.0",
-      "purl" : "pkg:npm/simple-update-notifier@%401.1.0"
+      "version" : "1.1.0",
+      "purl" : "pkg:npm/simple-update-notifier@1.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/supports-color@%405.5.0",
+      "bom-ref" : "pkg:npm/supports-color@5.5.0",
       "name" : "supports-color",
-      "version" : "@5.5.0",
-      "purl" : "pkg:npm/supports-color@%405.5.0"
+      "version" : "5.5.0",
+      "purl" : "pkg:npm/supports-color@5.5.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/touch@%403.1.1",
+      "bom-ref" : "pkg:npm/touch@3.1.1",
       "name" : "touch",
-      "version" : "@3.1.1",
-      "purl" : "pkg:npm/touch@%403.1.1"
+      "version" : "3.1.1",
+      "purl" : "pkg:npm/touch@3.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/undefsafe@%402.0.5",
+      "bom-ref" : "pkg:npm/undefsafe@2.0.5",
       "name" : "undefsafe",
-      "version" : "@2.0.5",
-      "purl" : "pkg:npm/undefsafe@%402.0.5"
+      "version" : "2.0.5",
+      "purl" : "pkg:npm/undefsafe@2.0.5"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/debug@%403.2.7",
+      "bom-ref" : "pkg:npm/debug@3.2.7",
       "name" : "debug",
-      "version" : "@3.2.7",
-      "purl" : "pkg:npm/debug@%403.2.7"
+      "version" : "3.2.7",
+      "purl" : "pkg:npm/debug@3.2.7"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/follow-redirects@%401.5.10",
+      "bom-ref" : "pkg:npm/follow-redirects@1.5.10",
       "name" : "follow-redirects",
-      "version" : "@1.5.10",
-      "purl" : "pkg:npm/follow-redirects@%401.5.10"
+      "version" : "1.5.10",
+      "purl" : "pkg:npm/follow-redirects@1.5.10"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40types/node@%4022.14.1",
+      "bom-ref" : "pkg:npm/%40types/node@22.14.1",
       "group" : "@types",
       "name" : "node",
-      "version" : "@22.14.1",
-      "purl" : "pkg:npm/%40types/node@%4022.14.1"
+      "version" : "22.14.1",
+      "purl" : "pkg:npm/%40types/node@22.14.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/%40types/bson@%404.2.4",
+      "bom-ref" : "pkg:npm/%40types/bson@4.2.4",
       "group" : "@types",
       "name" : "bson",
-      "version" : "@4.2.4",
-      "purl" : "pkg:npm/%40types/bson@%404.2.4"
+      "version" : "4.2.4",
+      "purl" : "pkg:npm/%40types/bson@4.2.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bson@%406.10.3",
+      "bom-ref" : "pkg:npm/bson@6.10.3",
       "name" : "bson",
-      "version" : "@6.10.3",
-      "purl" : "pkg:npm/bson@%406.10.3"
+      "version" : "6.10.3",
+      "purl" : "pkg:npm/bson@6.10.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mime-types@%402.1.35",
+      "bom-ref" : "pkg:npm/mime-types@2.1.35",
       "name" : "mime-types",
-      "version" : "@2.1.35",
-      "purl" : "pkg:npm/mime-types@%402.1.35"
+      "version" : "2.1.35",
+      "purl" : "pkg:npm/mime-types@2.1.35"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/negotiator@%400.6.3",
+      "bom-ref" : "pkg:npm/negotiator@0.6.3",
       "name" : "negotiator",
-      "version" : "@0.6.3",
-      "purl" : "pkg:npm/negotiator@%400.6.3"
+      "version" : "0.6.3",
+      "purl" : "pkg:npm/negotiator@0.6.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bytes@%403.1.2",
+      "bom-ref" : "pkg:npm/bytes@3.1.2",
       "name" : "bytes",
-      "version" : "@3.1.2",
-      "purl" : "pkg:npm/bytes@%403.1.2"
+      "version" : "3.1.2",
+      "purl" : "pkg:npm/bytes@3.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/destroy@%401.2.0",
+      "bom-ref" : "pkg:npm/destroy@1.2.0",
       "name" : "destroy",
-      "version" : "@1.2.0",
-      "purl" : "pkg:npm/destroy@%401.2.0"
+      "version" : "1.2.0",
+      "purl" : "pkg:npm/destroy@1.2.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/iconv-lite@%400.4.24",
+      "bom-ref" : "pkg:npm/iconv-lite@0.4.24",
       "name" : "iconv-lite",
-      "version" : "@0.4.24",
-      "purl" : "pkg:npm/iconv-lite@%400.4.24"
+      "version" : "0.4.24",
+      "purl" : "pkg:npm/iconv-lite@0.4.24"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/raw-body@%402.5.2",
+      "bom-ref" : "pkg:npm/raw-body@2.5.2",
       "name" : "raw-body",
-      "version" : "@2.5.2",
-      "purl" : "pkg:npm/raw-body@%402.5.2"
+      "version" : "2.5.2",
+      "purl" : "pkg:npm/raw-body@2.5.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/unpipe@%401.0.0",
+      "bom-ref" : "pkg:npm/unpipe@1.0.0",
       "name" : "unpipe",
-      "version" : "@1.0.0",
-      "purl" : "pkg:npm/unpipe@%401.0.0"
+      "version" : "1.0.0",
+      "purl" : "pkg:npm/unpipe@1.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/anymatch@%403.1.3",
+      "bom-ref" : "pkg:npm/anymatch@3.1.3",
       "name" : "anymatch",
-      "version" : "@3.1.3",
-      "purl" : "pkg:npm/anymatch@%403.1.3"
+      "version" : "3.1.3",
+      "purl" : "pkg:npm/anymatch@3.1.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/braces@%403.0.3",
+      "bom-ref" : "pkg:npm/braces@3.0.3",
       "name" : "braces",
-      "version" : "@3.0.3",
-      "purl" : "pkg:npm/braces@%403.0.3"
+      "version" : "3.0.3",
+      "purl" : "pkg:npm/braces@3.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/glob-parent@%405.1.2",
+      "bom-ref" : "pkg:npm/glob-parent@5.1.2",
       "name" : "glob-parent",
-      "version" : "@5.1.2",
-      "purl" : "pkg:npm/glob-parent@%405.1.2"
+      "version" : "5.1.2",
+      "purl" : "pkg:npm/glob-parent@5.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/is-binary-path@%402.1.0",
+      "bom-ref" : "pkg:npm/is-binary-path@2.1.0",
       "name" : "is-binary-path",
-      "version" : "@2.1.0",
-      "purl" : "pkg:npm/is-binary-path@%402.1.0"
+      "version" : "2.1.0",
+      "purl" : "pkg:npm/is-binary-path@2.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/is-glob@%404.0.3",
+      "bom-ref" : "pkg:npm/is-glob@4.0.3",
       "name" : "is-glob",
-      "version" : "@4.0.3",
-      "purl" : "pkg:npm/is-glob@%404.0.3"
+      "version" : "4.0.3",
+      "purl" : "pkg:npm/is-glob@4.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/normalize-path@%403.0.0",
+      "bom-ref" : "pkg:npm/normalize-path@3.0.0",
       "name" : "normalize-path",
-      "version" : "@3.0.0",
-      "purl" : "pkg:npm/normalize-path@%403.0.0"
+      "version" : "3.0.0",
+      "purl" : "pkg:npm/normalize-path@3.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/readdirp@%403.6.0",
+      "bom-ref" : "pkg:npm/readdirp@3.6.0",
       "name" : "readdirp",
-      "version" : "@3.6.0",
-      "purl" : "pkg:npm/readdirp@%403.6.0"
+      "version" : "3.6.0",
+      "purl" : "pkg:npm/readdirp@3.6.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/fsevents@%402.3.3",
+      "bom-ref" : "pkg:npm/fsevents@2.3.3",
       "name" : "fsevents",
-      "version" : "@2.3.3",
-      "purl" : "pkg:npm/fsevents@%402.3.3"
+      "version" : "2.3.3",
+      "purl" : "pkg:npm/fsevents@2.3.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/debug@%403.1.0",
+      "bom-ref" : "pkg:npm/debug@3.1.0",
       "name" : "debug",
-      "version" : "@3.1.0",
-      "purl" : "pkg:npm/debug@%403.1.0"
+      "version" : "3.1.0",
+      "purl" : "pkg:npm/debug@3.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/inherits@%402.0.4",
+      "bom-ref" : "pkg:npm/inherits@2.0.4",
       "name" : "inherits",
-      "version" : "@2.0.4",
-      "purl" : "pkg:npm/inherits@%402.0.4"
+      "version" : "2.0.4",
+      "purl" : "pkg:npm/inherits@2.0.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/toidentifier@%401.0.1",
+      "bom-ref" : "pkg:npm/toidentifier@1.0.1",
       "name" : "toidentifier",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/toidentifier@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/toidentifier@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/jwa@%401.4.1",
+      "bom-ref" : "pkg:npm/jwa@1.4.1",
       "name" : "jwa",
-      "version" : "@1.4.1",
-      "purl" : "pkg:npm/jwa@%401.4.1"
+      "version" : "1.4.1",
+      "purl" : "pkg:npm/jwa@1.4.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/brace-expansion@%401.1.11",
+      "bom-ref" : "pkg:npm/brace-expansion@1.1.11",
       "name" : "brace-expansion",
-      "version" : "@1.1.11",
-      "purl" : "pkg:npm/brace-expansion@%401.1.11"
+      "version" : "1.1.11",
+      "purl" : "pkg:npm/brace-expansion@1.1.11"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bl@%402.2.1",
+      "bom-ref" : "pkg:npm/bl@2.2.1",
       "name" : "bl",
-      "version" : "@2.2.1",
-      "purl" : "pkg:npm/bl@%402.2.1"
+      "version" : "2.2.1",
+      "purl" : "pkg:npm/bl@2.2.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/denque@%401.5.1",
+      "bom-ref" : "pkg:npm/denque@1.5.1",
       "name" : "denque",
-      "version" : "@1.5.1",
-      "purl" : "pkg:npm/denque@%401.5.1"
+      "version" : "1.5.1",
+      "purl" : "pkg:npm/denque@1.5.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/saslprep@%401.0.3",
+      "bom-ref" : "pkg:npm/saslprep@1.0.3",
       "name" : "saslprep",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/saslprep@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/saslprep@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/optional-require@%401.1.8",
+      "bom-ref" : "pkg:npm/optional-require@1.1.8",
       "name" : "optional-require",
-      "version" : "@1.1.8",
-      "purl" : "pkg:npm/optional-require@%401.1.8"
+      "version" : "1.1.8",
+      "purl" : "pkg:npm/optional-require@1.1.8"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/require-at@%401.0.6",
+      "bom-ref" : "pkg:npm/require-at@1.0.6",
       "name" : "require-at",
-      "version" : "@1.0.6",
-      "purl" : "pkg:npm/require-at@%401.0.6"
+      "version" : "1.0.6",
+      "purl" : "pkg:npm/require-at@1.0.6"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/bluebird@%403.5.1",
+      "bom-ref" : "pkg:npm/bluebird@3.5.1",
       "name" : "bluebird",
-      "version" : "@3.5.1",
-      "purl" : "pkg:npm/bluebird@%403.5.1"
+      "version" : "3.5.1",
+      "purl" : "pkg:npm/bluebird@3.5.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/safe-buffer@%405.1.2",
+      "bom-ref" : "pkg:npm/safe-buffer@5.1.2",
       "name" : "safe-buffer",
-      "version" : "@5.1.2",
-      "purl" : "pkg:npm/safe-buffer@%405.1.2"
+      "version" : "5.1.2",
+      "purl" : "pkg:npm/safe-buffer@5.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ee-first@%401.1.1",
+      "bom-ref" : "pkg:npm/ee-first@1.1.1",
       "name" : "ee-first",
-      "version" : "@1.1.1",
-      "purl" : "pkg:npm/ee-first@%401.1.1"
+      "version" : "1.1.1",
+      "purl" : "pkg:npm/ee-first@1.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/forwarded@%400.2.0",
+      "bom-ref" : "pkg:npm/forwarded@0.2.0",
       "name" : "forwarded",
-      "version" : "@0.2.0",
-      "purl" : "pkg:npm/forwarded@%400.2.0"
+      "version" : "0.2.0",
+      "purl" : "pkg:npm/forwarded@0.2.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ipaddr.js@%401.9.1",
+      "bom-ref" : "pkg:npm/ipaddr.js@1.9.1",
       "name" : "ipaddr.js",
-      "version" : "@1.9.1",
-      "purl" : "pkg:npm/ipaddr.js@%401.9.1"
+      "version" : "1.9.1",
+      "purl" : "pkg:npm/ipaddr.js@1.9.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/side-channel@%401.1.0",
+      "bom-ref" : "pkg:npm/side-channel@1.1.0",
       "name" : "side-channel",
-      "version" : "@1.1.0",
-      "purl" : "pkg:npm/side-channel@%401.1.0"
+      "version" : "1.1.0",
+      "purl" : "pkg:npm/side-channel@1.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mime@%401.6.0",
+      "bom-ref" : "pkg:npm/mime@1.6.0",
       "name" : "mime",
-      "version" : "@1.6.0",
-      "purl" : "pkg:npm/mime@%401.6.0"
+      "version" : "1.6.0",
+      "purl" : "pkg:npm/mime@1.6.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/encodeurl@%401.0.2",
+      "bom-ref" : "pkg:npm/encodeurl@1.0.2",
       "name" : "encodeurl",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/encodeurl@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/encodeurl@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/semver@%407.0.0",
+      "bom-ref" : "pkg:npm/semver@7.0.0",
       "name" : "semver",
-      "version" : "@7.0.0",
-      "purl" : "pkg:npm/semver@%407.0.0"
+      "version" : "7.0.0",
+      "purl" : "pkg:npm/semver@7.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/has-flag@%403.0.0",
+      "bom-ref" : "pkg:npm/has-flag@3.0.0",
       "name" : "has-flag",
-      "version" : "@3.0.0",
-      "purl" : "pkg:npm/has-flag@%403.0.0"
+      "version" : "3.0.0",
+      "purl" : "pkg:npm/has-flag@3.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/media-typer@%400.3.0",
+      "bom-ref" : "pkg:npm/media-typer@0.3.0",
       "name" : "media-typer",
-      "version" : "@0.3.0",
-      "purl" : "pkg:npm/media-typer@%400.3.0"
+      "version" : "0.3.0",
+      "purl" : "pkg:npm/media-typer@0.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/undici-types@%406.21.0",
+      "bom-ref" : "pkg:npm/undici-types@6.21.0",
       "name" : "undici-types",
-      "version" : "@6.21.0",
-      "purl" : "pkg:npm/undici-types@%406.21.0"
+      "version" : "6.21.0",
+      "purl" : "pkg:npm/undici-types@6.21.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/picomatch@%402.3.1",
+      "bom-ref" : "pkg:npm/picomatch@2.3.1",
       "name" : "picomatch",
-      "version" : "@2.3.1",
-      "purl" : "pkg:npm/picomatch@%402.3.1"
+      "version" : "2.3.1",
+      "purl" : "pkg:npm/picomatch@2.3.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/readable-stream@%402.3.8",
+      "bom-ref" : "pkg:npm/readable-stream@2.3.8",
       "name" : "readable-stream",
-      "version" : "@2.3.8",
-      "purl" : "pkg:npm/readable-stream@%402.3.8"
+      "version" : "2.3.8",
+      "purl" : "pkg:npm/readable-stream@2.3.8"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/balanced-match@%401.0.2",
+      "bom-ref" : "pkg:npm/balanced-match@1.0.2",
       "name" : "balanced-match",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/balanced-match@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/balanced-match@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/concat-map@%400.0.1",
+      "bom-ref" : "pkg:npm/concat-map@0.0.1",
       "name" : "concat-map",
-      "version" : "@0.0.1",
-      "purl" : "pkg:npm/concat-map@%400.0.1"
+      "version" : "0.0.1",
+      "purl" : "pkg:npm/concat-map@0.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/fill-range@%407.1.1",
+      "bom-ref" : "pkg:npm/fill-range@7.1.1",
       "name" : "fill-range",
-      "version" : "@7.1.1",
-      "purl" : "pkg:npm/fill-range@%407.1.1"
+      "version" : "7.1.1",
+      "purl" : "pkg:npm/fill-range@7.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/safer-buffer@%402.1.2",
+      "bom-ref" : "pkg:npm/safer-buffer@2.1.2",
       "name" : "safer-buffer",
-      "version" : "@2.1.2",
-      "purl" : "pkg:npm/safer-buffer@%402.1.2"
+      "version" : "2.1.2",
+      "purl" : "pkg:npm/safer-buffer@2.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/binary-extensions@%402.3.0",
+      "bom-ref" : "pkg:npm/binary-extensions@2.3.0",
       "name" : "binary-extensions",
-      "version" : "@2.3.0",
-      "purl" : "pkg:npm/binary-extensions@%402.3.0"
+      "version" : "2.3.0",
+      "purl" : "pkg:npm/binary-extensions@2.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/is-extglob@%402.1.1",
+      "bom-ref" : "pkg:npm/is-extglob@2.1.1",
       "name" : "is-extglob",
-      "version" : "@2.1.1",
-      "purl" : "pkg:npm/is-extglob@%402.1.1"
+      "version" : "2.1.1",
+      "purl" : "pkg:npm/is-extglob@2.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/buffer-equal-constant-time@%401.0.1",
+      "bom-ref" : "pkg:npm/buffer-equal-constant-time@1.0.1",
       "name" : "buffer-equal-constant-time",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/buffer-equal-constant-time@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/buffer-equal-constant-time@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/ecdsa-sig-formatter@%401.0.11",
+      "bom-ref" : "pkg:npm/ecdsa-sig-formatter@1.0.11",
       "name" : "ecdsa-sig-formatter",
-      "version" : "@1.0.11",
-      "purl" : "pkg:npm/ecdsa-sig-formatter@%401.0.11"
+      "version" : "1.0.11",
+      "purl" : "pkg:npm/ecdsa-sig-formatter@1.0.11"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/mime-db@%401.52.0",
+      "bom-ref" : "pkg:npm/mime-db@1.52.0",
       "name" : "mime-db",
-      "version" : "@1.52.0",
-      "purl" : "pkg:npm/mime-db@%401.52.0"
+      "version" : "1.52.0",
+      "purl" : "pkg:npm/mime-db@1.52.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/sparse-bitfield@%403.0.3",
+      "bom-ref" : "pkg:npm/sparse-bitfield@3.0.3",
       "name" : "sparse-bitfield",
-      "version" : "@3.0.3",
-      "purl" : "pkg:npm/sparse-bitfield@%403.0.3"
+      "version" : "3.0.3",
+      "purl" : "pkg:npm/sparse-bitfield@3.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/es-errors@%401.3.0",
+      "bom-ref" : "pkg:npm/es-errors@1.3.0",
       "name" : "es-errors",
-      "version" : "@1.3.0",
-      "purl" : "pkg:npm/es-errors@%401.3.0"
+      "version" : "1.3.0",
+      "purl" : "pkg:npm/es-errors@1.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/object-inspect@%401.13.4",
+      "bom-ref" : "pkg:npm/object-inspect@1.13.4",
       "name" : "object-inspect",
-      "version" : "@1.13.4",
-      "purl" : "pkg:npm/object-inspect@%401.13.4"
+      "version" : "1.13.4",
+      "purl" : "pkg:npm/object-inspect@1.13.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/side-channel-list@%401.0.0",
+      "bom-ref" : "pkg:npm/side-channel-list@1.0.0",
       "name" : "side-channel-list",
-      "version" : "@1.0.0",
-      "purl" : "pkg:npm/side-channel-list@%401.0.0"
+      "version" : "1.0.0",
+      "purl" : "pkg:npm/side-channel-list@1.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/side-channel-map@%401.0.1",
+      "bom-ref" : "pkg:npm/side-channel-map@1.0.1",
       "name" : "side-channel-map",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/side-channel-map@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/side-channel-map@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/side-channel-weakmap@%401.0.2",
+      "bom-ref" : "pkg:npm/side-channel-weakmap@1.0.2",
       "name" : "side-channel-weakmap",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/side-channel-weakmap@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/side-channel-weakmap@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/to-regex-range@%405.0.1",
+      "bom-ref" : "pkg:npm/to-regex-range@5.0.1",
       "name" : "to-regex-range",
-      "version" : "@5.0.1",
-      "purl" : "pkg:npm/to-regex-range@%405.0.1"
+      "version" : "5.0.1",
+      "purl" : "pkg:npm/to-regex-range@5.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/core-util-is@%401.0.3",
+      "bom-ref" : "pkg:npm/core-util-is@1.0.3",
       "name" : "core-util-is",
-      "version" : "@1.0.3",
-      "purl" : "pkg:npm/core-util-is@%401.0.3"
+      "version" : "1.0.3",
+      "purl" : "pkg:npm/core-util-is@1.0.3"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/isarray@%401.0.0",
+      "bom-ref" : "pkg:npm/isarray@1.0.0",
       "name" : "isarray",
-      "version" : "@1.0.0",
-      "purl" : "pkg:npm/isarray@%401.0.0"
+      "version" : "1.0.0",
+      "purl" : "pkg:npm/isarray@1.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/process-nextick-args@%402.0.1",
+      "bom-ref" : "pkg:npm/process-nextick-args@2.0.1",
       "name" : "process-nextick-args",
-      "version" : "@2.0.1",
-      "purl" : "pkg:npm/process-nextick-args@%402.0.1"
+      "version" : "2.0.1",
+      "purl" : "pkg:npm/process-nextick-args@2.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/string_decoder@%401.1.1",
+      "bom-ref" : "pkg:npm/string_decoder@1.1.1",
       "name" : "string_decoder",
-      "version" : "@1.1.1",
-      "purl" : "pkg:npm/string_decoder@%401.1.1"
+      "version" : "1.1.1",
+      "purl" : "pkg:npm/string_decoder@1.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/util-deprecate@%401.0.2",
+      "bom-ref" : "pkg:npm/util-deprecate@1.0.2",
       "name" : "util-deprecate",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/util-deprecate@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/util-deprecate@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/call-bound@%401.0.4",
+      "bom-ref" : "pkg:npm/call-bound@1.0.4",
       "name" : "call-bound",
-      "version" : "@1.0.4",
-      "purl" : "pkg:npm/call-bound@%401.0.4"
+      "version" : "1.0.4",
+      "purl" : "pkg:npm/call-bound@1.0.4"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/get-intrinsic@%401.3.0",
+      "bom-ref" : "pkg:npm/get-intrinsic@1.3.0",
       "name" : "get-intrinsic",
-      "version" : "@1.3.0",
-      "purl" : "pkg:npm/get-intrinsic@%401.3.0"
+      "version" : "1.3.0",
+      "purl" : "pkg:npm/get-intrinsic@1.3.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/memory-pager@%401.5.0",
+      "bom-ref" : "pkg:npm/memory-pager@1.5.0",
       "name" : "memory-pager",
-      "version" : "@1.5.0",
-      "purl" : "pkg:npm/memory-pager@%401.5.0"
+      "version" : "1.5.0",
+      "purl" : "pkg:npm/memory-pager@1.5.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/call-bind-apply-helpers@%401.0.2",
+      "bom-ref" : "pkg:npm/call-bind-apply-helpers@1.0.2",
       "name" : "call-bind-apply-helpers",
-      "version" : "@1.0.2",
-      "purl" : "pkg:npm/call-bind-apply-helpers@%401.0.2"
+      "version" : "1.0.2",
+      "purl" : "pkg:npm/call-bind-apply-helpers@1.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/es-define-property@%401.0.1",
+      "bom-ref" : "pkg:npm/es-define-property@1.0.1",
       "name" : "es-define-property",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/es-define-property@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/es-define-property@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/es-object-atoms@%401.1.1",
+      "bom-ref" : "pkg:npm/es-object-atoms@1.1.1",
       "name" : "es-object-atoms",
-      "version" : "@1.1.1",
-      "purl" : "pkg:npm/es-object-atoms@%401.1.1"
+      "version" : "1.1.1",
+      "purl" : "pkg:npm/es-object-atoms@1.1.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/function-bind@%401.1.2",
+      "bom-ref" : "pkg:npm/function-bind@1.1.2",
       "name" : "function-bind",
-      "version" : "@1.1.2",
-      "purl" : "pkg:npm/function-bind@%401.1.2"
+      "version" : "1.1.2",
+      "purl" : "pkg:npm/function-bind@1.1.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/get-proto@%401.0.1",
+      "bom-ref" : "pkg:npm/get-proto@1.0.1",
       "name" : "get-proto",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/get-proto@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/get-proto@1.0.1"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/gopd@%401.2.0",
+      "bom-ref" : "pkg:npm/gopd@1.2.0",
       "name" : "gopd",
-      "version" : "@1.2.0",
-      "purl" : "pkg:npm/gopd@%401.2.0"
+      "version" : "1.2.0",
+      "purl" : "pkg:npm/gopd@1.2.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/has-symbols@%401.1.0",
+      "bom-ref" : "pkg:npm/has-symbols@1.1.0",
       "name" : "has-symbols",
-      "version" : "@1.1.0",
-      "purl" : "pkg:npm/has-symbols@%401.1.0"
+      "version" : "1.1.0",
+      "purl" : "pkg:npm/has-symbols@1.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/hasown@%402.0.2",
+      "bom-ref" : "pkg:npm/hasown@2.0.2",
       "name" : "hasown",
-      "version" : "@2.0.2",
-      "purl" : "pkg:npm/hasown@%402.0.2"
+      "version" : "2.0.2",
+      "purl" : "pkg:npm/hasown@2.0.2"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/math-intrinsics@%401.1.0",
+      "bom-ref" : "pkg:npm/math-intrinsics@1.1.0",
       "name" : "math-intrinsics",
-      "version" : "@1.1.0",
-      "purl" : "pkg:npm/math-intrinsics@%401.1.0"
+      "version" : "1.1.0",
+      "purl" : "pkg:npm/math-intrinsics@1.1.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/is-number@%407.0.0",
+      "bom-ref" : "pkg:npm/is-number@7.0.0",
       "name" : "is-number",
-      "version" : "@7.0.0",
-      "purl" : "pkg:npm/is-number@%407.0.0"
+      "version" : "7.0.0",
+      "purl" : "pkg:npm/is-number@7.0.0"
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:npm/dunder-proto@%401.0.1",
+      "bom-ref" : "pkg:npm/dunder-proto@1.0.1",
       "name" : "dunder-proto",
-      "version" : "@1.0.1",
-      "purl" : "pkg:npm/dunder-proto@%401.0.1"
+      "version" : "1.0.1",
+      "purl" : "pkg:npm/dunder-proto@1.0.1"
     }
   ],
   "dependencies" : [
     {
       "ref" : "pkg:npm/backend@1.0.0",
       "dependsOn" : [
-        "pkg:npm/%40hapi/joi@%4017.1.1",
-        "pkg:npm/backend@%400.0.0",
-        "pkg:npm/bcryptjs@%402.4.3",
-        "pkg:npm/dotenv@%408.6.0",
-        "pkg:npm/express@%404.21.2",
-        "pkg:npm/jsonwebtoken@%408.5.1",
-        "pkg:npm/mongoose@%405.13.23",
-        "pkg:npm/nodemon@%402.0.22",
-        "pkg:npm/axios@%400.19.2"
+        "pkg:npm/%40hapi/joi@17.1.1",
+        "pkg:npm/backend@0.0.0",
+        "pkg:npm/bcryptjs@2.4.3",
+        "pkg:npm/dotenv@8.6.0",
+        "pkg:npm/express@4.21.2",
+        "pkg:npm/jsonwebtoken@8.5.1",
+        "pkg:npm/mongoose@5.13.23",
+        "pkg:npm/nodemon@2.0.22",
+        "pkg:npm/axios@0.19.2"
       ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/joi@%4017.1.1",
+      "ref" : "pkg:npm/%40hapi/joi@17.1.1",
       "dependsOn" : [
-        "pkg:npm/%40hapi/address@%404.1.0",
-        "pkg:npm/%40hapi/formula@%402.0.0",
-        "pkg:npm/%40hapi/hoek@%409.3.0",
-        "pkg:npm/%40hapi/pinpoint@%402.0.1",
-        "pkg:npm/%40hapi/topo@%405.1.0"
+        "pkg:npm/%40hapi/address@4.1.0",
+        "pkg:npm/%40hapi/formula@2.0.0",
+        "pkg:npm/%40hapi/hoek@9.3.0",
+        "pkg:npm/%40hapi/pinpoint@2.0.1",
+        "pkg:npm/%40hapi/topo@5.1.0"
       ]
     },
     {
-      "ref" : "pkg:npm/backend@%400.0.0",
+      "ref" : "pkg:npm/backend@0.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/bcryptjs@%402.4.3",
+      "ref" : "pkg:npm/bcryptjs@2.4.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/dotenv@%408.6.0",
+      "ref" : "pkg:npm/dotenv@8.6.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/express@%404.21.2",
+      "ref" : "pkg:npm/express@4.21.2",
       "dependsOn" : [
-        "pkg:npm/accepts@%401.3.8",
-        "pkg:npm/array-flatten@%401.1.1",
-        "pkg:npm/body-parser@%401.20.3",
-        "pkg:npm/content-disposition@%400.5.4",
-        "pkg:npm/content-type@%401.0.5",
-        "pkg:npm/cookie@%400.7.1",
-        "pkg:npm/cookie-signature@%401.0.6",
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/depd@%402.0.0",
-        "pkg:npm/encodeurl@%402.0.0",
-        "pkg:npm/escape-html@%401.0.3",
-        "pkg:npm/etag@%401.8.1",
-        "pkg:npm/finalhandler@%401.3.1",
-        "pkg:npm/fresh@%400.5.2",
-        "pkg:npm/http-errors@%402.0.0",
-        "pkg:npm/merge-descriptors@%401.0.3",
-        "pkg:npm/methods@%401.1.2",
-        "pkg:npm/on-finished@%402.4.1",
-        "pkg:npm/parseurl@%401.3.3",
-        "pkg:npm/path-to-regexp@%400.1.12",
-        "pkg:npm/proxy-addr@%402.0.7",
-        "pkg:npm/qs@%406.13.0",
-        "pkg:npm/range-parser@%401.2.1",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/send@%400.19.0",
-        "pkg:npm/serve-static@%401.16.2",
-        "pkg:npm/setprototypeof@%401.2.0",
-        "pkg:npm/statuses@%402.0.1",
-        "pkg:npm/type-is@%401.6.18",
-        "pkg:npm/utils-merge@%401.0.1",
-        "pkg:npm/vary@%401.1.2"
+        "pkg:npm/accepts@1.3.8",
+        "pkg:npm/array-flatten@1.1.1",
+        "pkg:npm/body-parser@1.20.3",
+        "pkg:npm/content-disposition@0.5.4",
+        "pkg:npm/content-type@1.0.5",
+        "pkg:npm/cookie@0.7.1",
+        "pkg:npm/cookie-signature@1.0.6",
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/depd@2.0.0",
+        "pkg:npm/encodeurl@2.0.0",
+        "pkg:npm/escape-html@1.0.3",
+        "pkg:npm/etag@1.8.1",
+        "pkg:npm/finalhandler@1.3.1",
+        "pkg:npm/fresh@0.5.2",
+        "pkg:npm/http-errors@2.0.0",
+        "pkg:npm/merge-descriptors@1.0.3",
+        "pkg:npm/methods@1.1.2",
+        "pkg:npm/on-finished@2.4.1",
+        "pkg:npm/parseurl@1.3.3",
+        "pkg:npm/path-to-regexp@0.1.12",
+        "pkg:npm/proxy-addr@2.0.7",
+        "pkg:npm/qs@6.13.0",
+        "pkg:npm/range-parser@1.2.1",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/send@0.19.0",
+        "pkg:npm/serve-static@1.16.2",
+        "pkg:npm/setprototypeof@1.2.0",
+        "pkg:npm/statuses@2.0.1",
+        "pkg:npm/type-is@1.6.18",
+        "pkg:npm/utils-merge@1.0.1",
+        "pkg:npm/vary@1.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/jsonwebtoken@%408.5.1",
+      "ref" : "pkg:npm/jsonwebtoken@8.5.1",
       "dependsOn" : [
-        "pkg:npm/jws@%403.2.2",
-        "pkg:npm/lodash.includes@%404.3.0",
-        "pkg:npm/lodash.isboolean@%403.0.3",
-        "pkg:npm/lodash.isinteger@%404.0.4",
-        "pkg:npm/lodash.isnumber@%403.0.3",
-        "pkg:npm/lodash.isplainobject@%404.0.6",
-        "pkg:npm/lodash.isstring@%404.0.1",
-        "pkg:npm/lodash.once@%404.1.1",
-        "pkg:npm/ms@%402.1.3",
-        "pkg:npm/semver@%405.7.2"
+        "pkg:npm/jws@3.2.2",
+        "pkg:npm/lodash.includes@4.3.0",
+        "pkg:npm/lodash.isboolean@3.0.3",
+        "pkg:npm/lodash.isinteger@4.0.4",
+        "pkg:npm/lodash.isnumber@3.0.3",
+        "pkg:npm/lodash.isplainobject@4.0.6",
+        "pkg:npm/lodash.isstring@4.0.1",
+        "pkg:npm/lodash.once@4.1.1",
+        "pkg:npm/ms@2.1.3",
+        "pkg:npm/semver@5.7.2"
       ]
     },
     {
-      "ref" : "pkg:npm/mongoose@%405.13.23",
+      "ref" : "pkg:npm/mongoose@5.13.23",
       "dependsOn" : [
-        "pkg:npm/%40types/bson@%404.0.5",
-        "pkg:npm/%40types/mongodb@%403.6.20",
-        "pkg:npm/bson@%401.1.6",
-        "pkg:npm/kareem@%402.3.2",
-        "pkg:npm/mongodb@%403.7.4",
-        "pkg:npm/mongoose-legacy-pluralize@%401.0.2",
-        "pkg:npm/mpath@%400.8.4",
-        "pkg:npm/mquery@%403.2.5",
-        "pkg:npm/ms@%402.1.3",
-        "pkg:npm/optional-require@%401.0.3",
-        "pkg:npm/regexp-clone@%401.0.0",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/sift@%4013.5.2",
-        "pkg:npm/sliced@%401.0.1",
-        "pkg:npm/ms@%402.1.2"
+        "pkg:npm/%40types/bson@4.0.5",
+        "pkg:npm/%40types/mongodb@3.6.20",
+        "pkg:npm/bson@1.1.6",
+        "pkg:npm/kareem@2.3.2",
+        "pkg:npm/mongodb@3.7.4",
+        "pkg:npm/mongoose-legacy-pluralize@1.0.2",
+        "pkg:npm/mpath@0.8.4",
+        "pkg:npm/mquery@3.2.5",
+        "pkg:npm/ms@2.1.3",
+        "pkg:npm/optional-require@1.0.3",
+        "pkg:npm/regexp-clone@1.0.0",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/sift@13.5.2",
+        "pkg:npm/sliced@1.0.1",
+        "pkg:npm/ms@2.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/nodemon@%402.0.22",
+      "ref" : "pkg:npm/nodemon@2.0.22",
       "dependsOn" : [
-        "pkg:npm/chokidar@%403.6.0",
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/ignore-by-default@%401.0.1",
-        "pkg:npm/minimatch@%403.1.2",
-        "pkg:npm/pstree.remy@%401.1.8",
-        "pkg:npm/semver@%405.7.2",
-        "pkg:npm/simple-update-notifier@%401.1.0",
-        "pkg:npm/supports-color@%405.5.0",
-        "pkg:npm/touch@%403.1.1",
-        "pkg:npm/undefsafe@%402.0.5",
-        "pkg:npm/debug@%403.2.7"
+        "pkg:npm/chokidar@3.6.0",
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/ignore-by-default@1.0.1",
+        "pkg:npm/minimatch@3.1.2",
+        "pkg:npm/pstree.remy@1.1.8",
+        "pkg:npm/semver@5.7.2",
+        "pkg:npm/simple-update-notifier@1.1.0",
+        "pkg:npm/supports-color@5.5.0",
+        "pkg:npm/touch@3.1.1",
+        "pkg:npm/undefsafe@2.0.5",
+        "pkg:npm/debug@3.2.7"
       ]
     },
     {
-      "ref" : "pkg:npm/axios@%400.19.2",
+      "ref" : "pkg:npm/axios@0.19.2",
       "dependsOn" : [
-        "pkg:npm/follow-redirects@%401.5.10"
+        "pkg:npm/follow-redirects@1.5.10"
       ]
     },
     {
-      "ref" : "pkg:npm/debug@%402.6.9",
+      "ref" : "pkg:npm/debug@2.6.9",
       "dependsOn" : [
-        "pkg:npm/ms@%402.1.3",
-        "pkg:npm/ms@%402.0.0"
+        "pkg:npm/ms@2.1.3",
+        "pkg:npm/ms@2.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/ms@%402.1.3",
+      "ref" : "pkg:npm/ms@2.1.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ms@%402.0.0",
+      "ref" : "pkg:npm/ms@2.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/address@%404.1.0",
+      "ref" : "pkg:npm/%40hapi/address@4.1.0",
       "dependsOn" : [
-        "pkg:npm/%40hapi/hoek@%409.3.0"
+        "pkg:npm/%40hapi/hoek@9.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/formula@%402.0.0",
+      "ref" : "pkg:npm/%40hapi/formula@2.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/hoek@%409.3.0",
+      "ref" : "pkg:npm/%40hapi/hoek@9.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/pinpoint@%402.0.1",
+      "ref" : "pkg:npm/%40hapi/pinpoint@2.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40hapi/topo@%405.1.0",
+      "ref" : "pkg:npm/%40hapi/topo@5.1.0",
       "dependsOn" : [
-        "pkg:npm/%40hapi/hoek@%409.3.0"
+        "pkg:npm/%40hapi/hoek@9.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/accepts@%401.3.8",
+      "ref" : "pkg:npm/accepts@1.3.8",
       "dependsOn" : [
-        "pkg:npm/mime-types@%402.1.35",
-        "pkg:npm/negotiator@%400.6.3"
+        "pkg:npm/mime-types@2.1.35",
+        "pkg:npm/negotiator@0.6.3"
       ]
     },
     {
-      "ref" : "pkg:npm/array-flatten@%401.1.1",
+      "ref" : "pkg:npm/array-flatten@1.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/body-parser@%401.20.3",
+      "ref" : "pkg:npm/body-parser@1.20.3",
       "dependsOn" : [
-        "pkg:npm/bytes@%403.1.2",
-        "pkg:npm/content-type@%401.0.5",
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/depd@%402.0.0",
-        "pkg:npm/destroy@%401.2.0",
-        "pkg:npm/http-errors@%402.0.0",
-        "pkg:npm/iconv-lite@%400.4.24",
-        "pkg:npm/on-finished@%402.4.1",
-        "pkg:npm/qs@%406.13.0",
-        "pkg:npm/raw-body@%402.5.2",
-        "pkg:npm/type-is@%401.6.18",
-        "pkg:npm/unpipe@%401.0.0"
+        "pkg:npm/bytes@3.1.2",
+        "pkg:npm/content-type@1.0.5",
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/depd@2.0.0",
+        "pkg:npm/destroy@1.2.0",
+        "pkg:npm/http-errors@2.0.0",
+        "pkg:npm/iconv-lite@0.4.24",
+        "pkg:npm/on-finished@2.4.1",
+        "pkg:npm/qs@6.13.0",
+        "pkg:npm/raw-body@2.5.2",
+        "pkg:npm/type-is@1.6.18",
+        "pkg:npm/unpipe@1.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/content-disposition@%400.5.4",
+      "ref" : "pkg:npm/content-disposition@0.5.4",
       "dependsOn" : [
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/content-type@%401.0.5",
+      "ref" : "pkg:npm/content-type@1.0.5",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/cookie@%400.7.1",
+      "ref" : "pkg:npm/cookie@0.7.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/cookie-signature@%401.0.6",
+      "ref" : "pkg:npm/cookie-signature@1.0.6",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/depd@%402.0.0",
+      "ref" : "pkg:npm/depd@2.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/encodeurl@%402.0.0",
+      "ref" : "pkg:npm/encodeurl@2.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/escape-html@%401.0.3",
+      "ref" : "pkg:npm/escape-html@1.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/etag@%401.8.1",
+      "ref" : "pkg:npm/etag@1.8.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/finalhandler@%401.3.1",
+      "ref" : "pkg:npm/finalhandler@1.3.1",
       "dependsOn" : [
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/encodeurl@%402.0.0",
-        "pkg:npm/escape-html@%401.0.3",
-        "pkg:npm/on-finished@%402.4.1",
-        "pkg:npm/parseurl@%401.3.3",
-        "pkg:npm/statuses@%402.0.1",
-        "pkg:npm/unpipe@%401.0.0"
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/encodeurl@2.0.0",
+        "pkg:npm/escape-html@1.0.3",
+        "pkg:npm/on-finished@2.4.1",
+        "pkg:npm/parseurl@1.3.3",
+        "pkg:npm/statuses@2.0.1",
+        "pkg:npm/unpipe@1.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/fresh@%400.5.2",
+      "ref" : "pkg:npm/fresh@0.5.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/http-errors@%402.0.0",
+      "ref" : "pkg:npm/http-errors@2.0.0",
       "dependsOn" : [
-        "pkg:npm/depd@%402.0.0",
-        "pkg:npm/inherits@%402.0.4",
-        "pkg:npm/setprototypeof@%401.2.0",
-        "pkg:npm/statuses@%402.0.1",
-        "pkg:npm/toidentifier@%401.0.1"
+        "pkg:npm/depd@2.0.0",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/setprototypeof@1.2.0",
+        "pkg:npm/statuses@2.0.1",
+        "pkg:npm/toidentifier@1.0.1"
       ]
     },
     {
-      "ref" : "pkg:npm/merge-descriptors@%401.0.3",
+      "ref" : "pkg:npm/merge-descriptors@1.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/methods@%401.1.2",
+      "ref" : "pkg:npm/methods@1.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/on-finished@%402.4.1",
+      "ref" : "pkg:npm/on-finished@2.4.1",
       "dependsOn" : [
-        "pkg:npm/ee-first@%401.1.1"
+        "pkg:npm/ee-first@1.1.1"
       ]
     },
     {
-      "ref" : "pkg:npm/parseurl@%401.3.3",
+      "ref" : "pkg:npm/parseurl@1.3.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/path-to-regexp@%400.1.12",
+      "ref" : "pkg:npm/path-to-regexp@0.1.12",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/proxy-addr@%402.0.7",
+      "ref" : "pkg:npm/proxy-addr@2.0.7",
       "dependsOn" : [
-        "pkg:npm/forwarded@%400.2.0",
-        "pkg:npm/ipaddr.js@%401.9.1"
+        "pkg:npm/forwarded@0.2.0",
+        "pkg:npm/ipaddr.js@1.9.1"
       ]
     },
     {
-      "ref" : "pkg:npm/qs@%406.13.0",
+      "ref" : "pkg:npm/qs@6.13.0",
       "dependsOn" : [
-        "pkg:npm/side-channel@%401.1.0"
+        "pkg:npm/side-channel@1.1.0"
       ]
     },
     {
-      "ref" : "pkg:npm/range-parser@%401.2.1",
+      "ref" : "pkg:npm/range-parser@1.2.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/safe-buffer@%405.2.1",
+      "ref" : "pkg:npm/safe-buffer@5.2.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/send@%400.19.0",
+      "ref" : "pkg:npm/send@0.19.0",
       "dependsOn" : [
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/depd@%402.0.0",
-        "pkg:npm/destroy@%401.2.0",
-        "pkg:npm/encodeurl@%402.0.0",
-        "pkg:npm/escape-html@%401.0.3",
-        "pkg:npm/etag@%401.8.1",
-        "pkg:npm/fresh@%400.5.2",
-        "pkg:npm/http-errors@%402.0.0",
-        "pkg:npm/mime@%401.6.0",
-        "pkg:npm/ms@%402.1.3",
-        "pkg:npm/on-finished@%402.4.1",
-        "pkg:npm/range-parser@%401.2.1",
-        "pkg:npm/statuses@%402.0.1",
-        "pkg:npm/encodeurl@%401.0.2"
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/depd@2.0.0",
+        "pkg:npm/destroy@1.2.0",
+        "pkg:npm/encodeurl@2.0.0",
+        "pkg:npm/escape-html@1.0.3",
+        "pkg:npm/etag@1.8.1",
+        "pkg:npm/fresh@0.5.2",
+        "pkg:npm/http-errors@2.0.0",
+        "pkg:npm/mime@1.6.0",
+        "pkg:npm/ms@2.1.3",
+        "pkg:npm/on-finished@2.4.1",
+        "pkg:npm/range-parser@1.2.1",
+        "pkg:npm/statuses@2.0.1",
+        "pkg:npm/encodeurl@1.0.2"
       ]
     },
     {
-      "ref" : "pkg:npm/serve-static@%401.16.2",
+      "ref" : "pkg:npm/serve-static@1.16.2",
       "dependsOn" : [
-        "pkg:npm/encodeurl@%402.0.0",
-        "pkg:npm/escape-html@%401.0.3",
-        "pkg:npm/parseurl@%401.3.3",
-        "pkg:npm/send@%400.19.0"
+        "pkg:npm/encodeurl@2.0.0",
+        "pkg:npm/escape-html@1.0.3",
+        "pkg:npm/parseurl@1.3.3",
+        "pkg:npm/send@0.19.0"
       ]
     },
     {
-      "ref" : "pkg:npm/setprototypeof@%401.2.0",
+      "ref" : "pkg:npm/setprototypeof@1.2.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/statuses@%402.0.1",
+      "ref" : "pkg:npm/statuses@2.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/type-is@%401.6.18",
+      "ref" : "pkg:npm/type-is@1.6.18",
       "dependsOn" : [
-        "pkg:npm/media-typer@%400.3.0",
-        "pkg:npm/mime-types@%402.1.35"
+        "pkg:npm/media-typer@0.3.0",
+        "pkg:npm/mime-types@2.1.35"
       ]
     },
     {
-      "ref" : "pkg:npm/utils-merge@%401.0.1",
+      "ref" : "pkg:npm/utils-merge@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/vary@%401.1.2",
+      "ref" : "pkg:npm/vary@1.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/jws@%403.2.2",
+      "ref" : "pkg:npm/jws@3.2.2",
       "dependsOn" : [
-        "pkg:npm/jwa@%401.4.1",
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/jwa@1.4.1",
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/lodash.includes@%404.3.0",
+      "ref" : "pkg:npm/lodash.includes@4.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isboolean@%403.0.3",
+      "ref" : "pkg:npm/lodash.isboolean@3.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isinteger@%404.0.4",
+      "ref" : "pkg:npm/lodash.isinteger@4.0.4",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isnumber@%403.0.3",
+      "ref" : "pkg:npm/lodash.isnumber@3.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isplainobject@%404.0.6",
+      "ref" : "pkg:npm/lodash.isplainobject@4.0.6",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.isstring@%404.0.1",
+      "ref" : "pkg:npm/lodash.isstring@4.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/lodash.once@%404.1.1",
+      "ref" : "pkg:npm/lodash.once@4.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/semver@%405.7.2",
+      "ref" : "pkg:npm/semver@5.7.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/%40types/bson@%404.0.5",
+      "ref" : "pkg:npm/%40types/bson@4.0.5",
       "dependsOn" : [
-        "pkg:npm/%40types/node@%4022.14.1"
+        "pkg:npm/%40types/node@22.14.1"
       ]
     },
     {
-      "ref" : "pkg:npm/%40types/mongodb@%403.6.20",
+      "ref" : "pkg:npm/%40types/mongodb@3.6.20",
       "dependsOn" : [
-        "pkg:npm/%40types/bson@%404.0.5",
-        "pkg:npm/%40types/node@%4022.14.1",
-        "pkg:npm/%40types/bson@%404.2.4",
-        "pkg:npm/bson@%406.10.3"
+        "pkg:npm/%40types/bson@4.0.5",
+        "pkg:npm/%40types/node@22.14.1",
+        "pkg:npm/%40types/bson@4.2.4",
+        "pkg:npm/bson@6.10.3"
       ]
     },
     {
-      "ref" : "pkg:npm/bson@%401.1.6",
+      "ref" : "pkg:npm/bson@1.1.6",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/kareem@%402.3.2",
+      "ref" : "pkg:npm/kareem@2.3.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/mongodb@%403.7.4",
+      "ref" : "pkg:npm/mongodb@3.7.4",
       "dependsOn" : [
-        "pkg:npm/bl@%402.2.1",
-        "pkg:npm/bson@%401.1.6",
-        "pkg:npm/denque@%401.5.1",
-        "pkg:npm/optional-require@%401.0.3",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/saslprep@%401.0.3",
-        "pkg:npm/optional-require@%401.1.8"
+        "pkg:npm/bl@2.2.1",
+        "pkg:npm/bson@1.1.6",
+        "pkg:npm/denque@1.5.1",
+        "pkg:npm/optional-require@1.0.3",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/saslprep@1.0.3",
+        "pkg:npm/optional-require@1.1.8"
       ]
     },
     {
-      "ref" : "pkg:npm/mongoose-legacy-pluralize@%401.0.2",
+      "ref" : "pkg:npm/mongoose-legacy-pluralize@1.0.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/mpath@%400.8.4",
+      "ref" : "pkg:npm/mpath@0.8.4",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/mquery@%403.2.5",
+      "ref" : "pkg:npm/mquery@3.2.5",
       "dependsOn" : [
-        "pkg:npm/bluebird@%403.5.1",
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/regexp-clone@%401.0.0",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/sliced@%401.0.1",
-        "pkg:npm/debug@%403.1.0",
-        "pkg:npm/safe-buffer@%405.1.2",
-        "pkg:npm/ms@%402.0.0"
+        "pkg:npm/bluebird@3.5.1",
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/regexp-clone@1.0.0",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/sliced@1.0.1",
+        "pkg:npm/debug@3.1.0",
+        "pkg:npm/safe-buffer@5.1.2",
+        "pkg:npm/ms@2.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/optional-require@%401.0.3",
+      "ref" : "pkg:npm/optional-require@1.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/regexp-clone@%401.0.0",
+      "ref" : "pkg:npm/regexp-clone@1.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/sift@%4013.5.2",
+      "ref" : "pkg:npm/sift@13.5.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/sliced@%401.0.1",
+      "ref" : "pkg:npm/sliced@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ms@%402.1.2",
+      "ref" : "pkg:npm/ms@2.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/chokidar@%403.6.0",
+      "ref" : "pkg:npm/chokidar@3.6.0",
       "dependsOn" : [
-        "pkg:npm/anymatch@%403.1.3",
-        "pkg:npm/braces@%403.0.3",
-        "pkg:npm/glob-parent@%405.1.2",
-        "pkg:npm/is-binary-path@%402.1.0",
-        "pkg:npm/is-glob@%404.0.3",
-        "pkg:npm/normalize-path@%403.0.0",
-        "pkg:npm/readdirp@%403.6.0",
-        "pkg:npm/fsevents@%402.3.3"
+        "pkg:npm/anymatch@3.1.3",
+        "pkg:npm/braces@3.0.3",
+        "pkg:npm/glob-parent@5.1.2",
+        "pkg:npm/is-binary-path@2.1.0",
+        "pkg:npm/is-glob@4.0.3",
+        "pkg:npm/normalize-path@3.0.0",
+        "pkg:npm/readdirp@3.6.0",
+        "pkg:npm/fsevents@2.3.3"
       ]
     },
     {
-      "ref" : "pkg:npm/ignore-by-default@%401.0.1",
+      "ref" : "pkg:npm/ignore-by-default@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/minimatch@%403.1.2",
+      "ref" : "pkg:npm/minimatch@3.1.2",
       "dependsOn" : [
-        "pkg:npm/brace-expansion@%401.1.11"
+        "pkg:npm/brace-expansion@1.1.11"
       ]
     },
     {
-      "ref" : "pkg:npm/pstree.remy@%401.1.8",
+      "ref" : "pkg:npm/pstree.remy@1.1.8",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/simple-update-notifier@%401.1.0",
+      "ref" : "pkg:npm/simple-update-notifier@1.1.0",
       "dependsOn" : [
-        "pkg:npm/semver@%405.7.2",
-        "pkg:npm/semver@%407.0.0"
+        "pkg:npm/semver@5.7.2",
+        "pkg:npm/semver@7.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/supports-color@%405.5.0",
+      "ref" : "pkg:npm/supports-color@5.5.0",
       "dependsOn" : [
-        "pkg:npm/has-flag@%403.0.0"
+        "pkg:npm/has-flag@3.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/touch@%403.1.1",
+      "ref" : "pkg:npm/touch@3.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/undefsafe@%402.0.5",
+      "ref" : "pkg:npm/undefsafe@2.0.5",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/debug@%403.2.7",
+      "ref" : "pkg:npm/debug@3.2.7",
       "dependsOn" : [
-        "pkg:npm/ms@%402.1.3"
+        "pkg:npm/ms@2.1.3"
       ]
     },
     {
-      "ref" : "pkg:npm/follow-redirects@%401.5.10",
+      "ref" : "pkg:npm/follow-redirects@1.5.10",
       "dependsOn" : [
-        "pkg:npm/debug@%402.6.9",
-        "pkg:npm/debug@%403.1.0",
-        "pkg:npm/ms@%402.0.0"
+        "pkg:npm/debug@2.6.9",
+        "pkg:npm/debug@3.1.0",
+        "pkg:npm/ms@2.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/%40types/node@%4022.14.1",
+      "ref" : "pkg:npm/%40types/node@22.14.1",
       "dependsOn" : [
-        "pkg:npm/undici-types@%406.21.0"
+        "pkg:npm/undici-types@6.21.0"
       ]
     },
     {
-      "ref" : "pkg:npm/%40types/bson@%404.2.4",
+      "ref" : "pkg:npm/%40types/bson@4.2.4",
       "dependsOn" : [
-        "pkg:npm/bson@%401.1.6"
+        "pkg:npm/bson@1.1.6"
       ]
     },
     {
-      "ref" : "pkg:npm/bson@%406.10.3",
+      "ref" : "pkg:npm/bson@6.10.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/mime-types@%402.1.35",
+      "ref" : "pkg:npm/mime-types@2.1.35",
       "dependsOn" : [
-        "pkg:npm/mime-db@%401.52.0"
+        "pkg:npm/mime-db@1.52.0"
       ]
     },
     {
-      "ref" : "pkg:npm/negotiator@%400.6.3",
+      "ref" : "pkg:npm/negotiator@0.6.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/bytes@%403.1.2",
+      "ref" : "pkg:npm/bytes@3.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/destroy@%401.2.0",
+      "ref" : "pkg:npm/destroy@1.2.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/iconv-lite@%400.4.24",
+      "ref" : "pkg:npm/iconv-lite@0.4.24",
       "dependsOn" : [
-        "pkg:npm/safer-buffer@%402.1.2"
+        "pkg:npm/safer-buffer@2.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/raw-body@%402.5.2",
+      "ref" : "pkg:npm/raw-body@2.5.2",
       "dependsOn" : [
-        "pkg:npm/bytes@%403.1.2",
-        "pkg:npm/http-errors@%402.0.0",
-        "pkg:npm/iconv-lite@%400.4.24",
-        "pkg:npm/unpipe@%401.0.0"
+        "pkg:npm/bytes@3.1.2",
+        "pkg:npm/http-errors@2.0.0",
+        "pkg:npm/iconv-lite@0.4.24",
+        "pkg:npm/unpipe@1.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/unpipe@%401.0.0",
+      "ref" : "pkg:npm/unpipe@1.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/anymatch@%403.1.3",
+      "ref" : "pkg:npm/anymatch@3.1.3",
       "dependsOn" : [
-        "pkg:npm/normalize-path@%403.0.0",
-        "pkg:npm/picomatch@%402.3.1"
+        "pkg:npm/normalize-path@3.0.0",
+        "pkg:npm/picomatch@2.3.1"
       ]
     },
     {
-      "ref" : "pkg:npm/braces@%403.0.3",
+      "ref" : "pkg:npm/braces@3.0.3",
       "dependsOn" : [
-        "pkg:npm/fill-range@%407.1.1"
+        "pkg:npm/fill-range@7.1.1"
       ]
     },
     {
-      "ref" : "pkg:npm/glob-parent@%405.1.2",
+      "ref" : "pkg:npm/glob-parent@5.1.2",
       "dependsOn" : [
-        "pkg:npm/is-glob@%404.0.3"
+        "pkg:npm/is-glob@4.0.3"
       ]
     },
     {
-      "ref" : "pkg:npm/is-binary-path@%402.1.0",
+      "ref" : "pkg:npm/is-binary-path@2.1.0",
       "dependsOn" : [
-        "pkg:npm/binary-extensions@%402.3.0"
+        "pkg:npm/binary-extensions@2.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/is-glob@%404.0.3",
+      "ref" : "pkg:npm/is-glob@4.0.3",
       "dependsOn" : [
-        "pkg:npm/is-extglob@%402.1.1"
+        "pkg:npm/is-extglob@2.1.1"
       ]
     },
     {
-      "ref" : "pkg:npm/normalize-path@%403.0.0",
+      "ref" : "pkg:npm/normalize-path@3.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/readdirp@%403.6.0",
+      "ref" : "pkg:npm/readdirp@3.6.0",
       "dependsOn" : [
-        "pkg:npm/picomatch@%402.3.1"
+        "pkg:npm/picomatch@2.3.1"
       ]
     },
     {
-      "ref" : "pkg:npm/fsevents@%402.3.3",
+      "ref" : "pkg:npm/fsevents@2.3.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/debug@%403.1.0",
+      "ref" : "pkg:npm/debug@3.1.0",
       "dependsOn" : [
-        "pkg:npm/ms@%402.1.3"
+        "pkg:npm/ms@2.1.3"
       ]
     },
     {
-      "ref" : "pkg:npm/inherits@%402.0.4",
+      "ref" : "pkg:npm/inherits@2.0.4",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/toidentifier@%401.0.1",
+      "ref" : "pkg:npm/toidentifier@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/jwa@%401.4.1",
+      "ref" : "pkg:npm/jwa@1.4.1",
       "dependsOn" : [
-        "pkg:npm/buffer-equal-constant-time@%401.0.1",
-        "pkg:npm/ecdsa-sig-formatter@%401.0.11",
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/buffer-equal-constant-time@1.0.1",
+        "pkg:npm/ecdsa-sig-formatter@1.0.11",
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/brace-expansion@%401.1.11",
+      "ref" : "pkg:npm/brace-expansion@1.1.11",
       "dependsOn" : [
-        "pkg:npm/balanced-match@%401.0.2",
-        "pkg:npm/concat-map@%400.0.1"
+        "pkg:npm/balanced-match@1.0.2",
+        "pkg:npm/concat-map@0.0.1"
       ]
     },
     {
-      "ref" : "pkg:npm/bl@%402.2.1",
+      "ref" : "pkg:npm/bl@2.2.1",
       "dependsOn" : [
-        "pkg:npm/readable-stream@%402.3.8",
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/readable-stream@2.3.8",
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/denque@%401.5.1",
+      "ref" : "pkg:npm/denque@1.5.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/saslprep@%401.0.3",
+      "ref" : "pkg:npm/saslprep@1.0.3",
       "dependsOn" : [
-        "pkg:npm/sparse-bitfield@%403.0.3"
+        "pkg:npm/sparse-bitfield@3.0.3"
       ]
     },
     {
-      "ref" : "pkg:npm/optional-require@%401.1.8",
+      "ref" : "pkg:npm/optional-require@1.1.8",
       "dependsOn" : [
-        "pkg:npm/require-at@%401.0.6"
+        "pkg:npm/require-at@1.0.6"
       ]
     },
     {
-      "ref" : "pkg:npm/require-at@%401.0.6",
+      "ref" : "pkg:npm/require-at@1.0.6",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/bluebird@%403.5.1",
+      "ref" : "pkg:npm/bluebird@3.5.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/safe-buffer@%405.1.2",
+      "ref" : "pkg:npm/safe-buffer@5.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ee-first@%401.1.1",
+      "ref" : "pkg:npm/ee-first@1.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/forwarded@%400.2.0",
+      "ref" : "pkg:npm/forwarded@0.2.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ipaddr.js@%401.9.1",
+      "ref" : "pkg:npm/ipaddr.js@1.9.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/side-channel@%401.1.0",
+      "ref" : "pkg:npm/side-channel@1.1.0",
       "dependsOn" : [
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/object-inspect@%401.13.4",
-        "pkg:npm/side-channel-list@%401.0.0",
-        "pkg:npm/side-channel-map@%401.0.1",
-        "pkg:npm/side-channel-weakmap@%401.0.2"
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/object-inspect@1.13.4",
+        "pkg:npm/side-channel-list@1.0.0",
+        "pkg:npm/side-channel-map@1.0.1",
+        "pkg:npm/side-channel-weakmap@1.0.2"
       ]
     },
     {
-      "ref" : "pkg:npm/mime@%401.6.0",
+      "ref" : "pkg:npm/mime@1.6.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/encodeurl@%401.0.2",
+      "ref" : "pkg:npm/encodeurl@1.0.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/semver@%407.0.0",
+      "ref" : "pkg:npm/semver@7.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/has-flag@%403.0.0",
+      "ref" : "pkg:npm/has-flag@3.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/media-typer@%400.3.0",
+      "ref" : "pkg:npm/media-typer@0.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/undici-types@%406.21.0",
+      "ref" : "pkg:npm/undici-types@6.21.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/picomatch@%402.3.1",
+      "ref" : "pkg:npm/picomatch@2.3.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/readable-stream@%402.3.8",
+      "ref" : "pkg:npm/readable-stream@2.3.8",
       "dependsOn" : [
-        "pkg:npm/core-util-is@%401.0.3",
-        "pkg:npm/inherits@%402.0.4",
-        "pkg:npm/isarray@%401.0.0",
-        "pkg:npm/process-nextick-args@%402.0.1",
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/string_decoder@%401.1.1",
-        "pkg:npm/util-deprecate@%401.0.2",
-        "pkg:npm/safe-buffer@%405.1.2"
+        "pkg:npm/core-util-is@1.0.3",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/isarray@1.0.0",
+        "pkg:npm/process-nextick-args@2.0.1",
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/string_decoder@1.1.1",
+        "pkg:npm/util-deprecate@1.0.2",
+        "pkg:npm/safe-buffer@5.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/balanced-match@%401.0.2",
+      "ref" : "pkg:npm/balanced-match@1.0.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/concat-map@%400.0.1",
+      "ref" : "pkg:npm/concat-map@0.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/fill-range@%407.1.1",
+      "ref" : "pkg:npm/fill-range@7.1.1",
       "dependsOn" : [
-        "pkg:npm/to-regex-range@%405.0.1"
+        "pkg:npm/to-regex-range@5.0.1"
       ]
     },
     {
-      "ref" : "pkg:npm/safer-buffer@%402.1.2",
+      "ref" : "pkg:npm/safer-buffer@2.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/binary-extensions@%402.3.0",
+      "ref" : "pkg:npm/binary-extensions@2.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/is-extglob@%402.1.1",
+      "ref" : "pkg:npm/is-extglob@2.1.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/buffer-equal-constant-time@%401.0.1",
+      "ref" : "pkg:npm/buffer-equal-constant-time@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/ecdsa-sig-formatter@%401.0.11",
+      "ref" : "pkg:npm/ecdsa-sig-formatter@1.0.11",
       "dependsOn" : [
-        "pkg:npm/safe-buffer@%405.2.1"
+        "pkg:npm/safe-buffer@5.2.1"
       ]
     },
     {
-      "ref" : "pkg:npm/mime-db@%401.52.0",
+      "ref" : "pkg:npm/mime-db@1.52.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/sparse-bitfield@%403.0.3",
+      "ref" : "pkg:npm/sparse-bitfield@3.0.3",
       "dependsOn" : [
-        "pkg:npm/memory-pager@%401.5.0"
+        "pkg:npm/memory-pager@1.5.0"
       ]
     },
     {
-      "ref" : "pkg:npm/es-errors@%401.3.0",
+      "ref" : "pkg:npm/es-errors@1.3.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/object-inspect@%401.13.4",
+      "ref" : "pkg:npm/object-inspect@1.13.4",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/side-channel-list@%401.0.0",
+      "ref" : "pkg:npm/side-channel-list@1.0.0",
       "dependsOn" : [
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/object-inspect@%401.13.4"
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/object-inspect@1.13.4"
       ]
     },
     {
-      "ref" : "pkg:npm/side-channel-map@%401.0.1",
+      "ref" : "pkg:npm/side-channel-map@1.0.1",
       "dependsOn" : [
-        "pkg:npm/call-bound@%401.0.4",
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/get-intrinsic@%401.3.0",
-        "pkg:npm/object-inspect@%401.13.4"
+        "pkg:npm/call-bound@1.0.4",
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/get-intrinsic@1.3.0",
+        "pkg:npm/object-inspect@1.13.4"
       ]
     },
     {
-      "ref" : "pkg:npm/side-channel-weakmap@%401.0.2",
+      "ref" : "pkg:npm/side-channel-weakmap@1.0.2",
       "dependsOn" : [
-        "pkg:npm/call-bound@%401.0.4",
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/get-intrinsic@%401.3.0",
-        "pkg:npm/object-inspect@%401.13.4",
-        "pkg:npm/side-channel-map@%401.0.1"
+        "pkg:npm/call-bound@1.0.4",
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/get-intrinsic@1.3.0",
+        "pkg:npm/object-inspect@1.13.4",
+        "pkg:npm/side-channel-map@1.0.1"
       ]
     },
     {
-      "ref" : "pkg:npm/to-regex-range@%405.0.1",
+      "ref" : "pkg:npm/to-regex-range@5.0.1",
       "dependsOn" : [
-        "pkg:npm/is-number@%407.0.0"
+        "pkg:npm/is-number@7.0.0"
       ]
     },
     {
-      "ref" : "pkg:npm/core-util-is@%401.0.3",
+      "ref" : "pkg:npm/core-util-is@1.0.3",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/isarray@%401.0.0",
+      "ref" : "pkg:npm/isarray@1.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/process-nextick-args@%402.0.1",
+      "ref" : "pkg:npm/process-nextick-args@2.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/string_decoder@%401.1.1",
+      "ref" : "pkg:npm/string_decoder@1.1.1",
       "dependsOn" : [
-        "pkg:npm/safe-buffer@%405.2.1",
-        "pkg:npm/safe-buffer@%405.1.2"
+        "pkg:npm/safe-buffer@5.2.1",
+        "pkg:npm/safe-buffer@5.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/util-deprecate@%401.0.2",
+      "ref" : "pkg:npm/util-deprecate@1.0.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/call-bound@%401.0.4",
+      "ref" : "pkg:npm/call-bound@1.0.4",
       "dependsOn" : [
-        "pkg:npm/call-bind-apply-helpers@%401.0.2",
-        "pkg:npm/get-intrinsic@%401.3.0"
+        "pkg:npm/call-bind-apply-helpers@1.0.2",
+        "pkg:npm/get-intrinsic@1.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/get-intrinsic@%401.3.0",
+      "ref" : "pkg:npm/get-intrinsic@1.3.0",
       "dependsOn" : [
-        "pkg:npm/call-bind-apply-helpers@%401.0.2",
-        "pkg:npm/es-define-property@%401.0.1",
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/es-object-atoms@%401.1.1",
-        "pkg:npm/function-bind@%401.1.2",
-        "pkg:npm/get-proto@%401.0.1",
-        "pkg:npm/gopd@%401.2.0",
-        "pkg:npm/has-symbols@%401.1.0",
-        "pkg:npm/hasown@%402.0.2",
-        "pkg:npm/math-intrinsics@%401.1.0"
+        "pkg:npm/call-bind-apply-helpers@1.0.2",
+        "pkg:npm/es-define-property@1.0.1",
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/es-object-atoms@1.1.1",
+        "pkg:npm/function-bind@1.1.2",
+        "pkg:npm/get-proto@1.0.1",
+        "pkg:npm/gopd@1.2.0",
+        "pkg:npm/has-symbols@1.1.0",
+        "pkg:npm/hasown@2.0.2",
+        "pkg:npm/math-intrinsics@1.1.0"
       ]
     },
     {
-      "ref" : "pkg:npm/memory-pager@%401.5.0",
+      "ref" : "pkg:npm/memory-pager@1.5.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/call-bind-apply-helpers@%401.0.2",
+      "ref" : "pkg:npm/call-bind-apply-helpers@1.0.2",
       "dependsOn" : [
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/function-bind@%401.1.2"
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/function-bind@1.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/es-define-property@%401.0.1",
+      "ref" : "pkg:npm/es-define-property@1.0.1",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/es-object-atoms@%401.1.1",
+      "ref" : "pkg:npm/es-object-atoms@1.1.1",
       "dependsOn" : [
-        "pkg:npm/es-errors@%401.3.0"
+        "pkg:npm/es-errors@1.3.0"
       ]
     },
     {
-      "ref" : "pkg:npm/function-bind@%401.1.2",
+      "ref" : "pkg:npm/function-bind@1.1.2",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/get-proto@%401.0.1",
+      "ref" : "pkg:npm/get-proto@1.0.1",
       "dependsOn" : [
-        "pkg:npm/dunder-proto@%401.0.1",
-        "pkg:npm/es-object-atoms@%401.1.1"
+        "pkg:npm/dunder-proto@1.0.1",
+        "pkg:npm/es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref" : "pkg:npm/gopd@%401.2.0",
+      "ref" : "pkg:npm/gopd@1.2.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/has-symbols@%401.1.0",
+      "ref" : "pkg:npm/has-symbols@1.1.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/hasown@%402.0.2",
+      "ref" : "pkg:npm/hasown@2.0.2",
       "dependsOn" : [
-        "pkg:npm/function-bind@%401.1.2"
+        "pkg:npm/function-bind@1.1.2"
       ]
     },
     {
-      "ref" : "pkg:npm/math-intrinsics@%401.1.0",
+      "ref" : "pkg:npm/math-intrinsics@1.1.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/is-number@%407.0.0",
+      "ref" : "pkg:npm/is-number@7.0.0",
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:npm/dunder-proto@%401.0.1",
+      "ref" : "pkg:npm/dunder-proto@1.0.1",
       "dependsOn" : [
-        "pkg:npm/call-bind-apply-helpers@%401.0.2",
-        "pkg:npm/es-errors@%401.3.0",
-        "pkg:npm/gopd@%401.2.0"
+        "pkg:npm/call-bind-apply-helpers@1.0.2",
+        "pkg:npm/es-errors@1.3.0",
+        "pkg:npm/gopd@1.2.0"
       ]
     }
   ]

--- a/test/utils/sbom_utils.js
+++ b/test/utils/sbom_utils.js
@@ -1,0 +1,116 @@
+/**
+ * Compares two SBOMs and throws an error if they don't match
+ * @param {string|Object} actualSbom - The actual SBOM to compare
+ * @param {string|Object} expectedSbom - The expected SBOM to compare against
+ * @throws {Error} If the SBOMs don't match, with a descriptive error message
+ */
+export function compareSboms(actualSbom, expectedSbom) {
+    // Parse the SBOMs if they're strings
+    const expected = typeof expectedSbom === 'string' ? JSON.parse(expectedSbom) : expectedSbom;
+    const actual = typeof actualSbom === 'string' ? JSON.parse(actualSbom) : actualSbom;
+
+    // Helper function to get component names
+    const getComponentNames = (components) => components.map(c => c.name).sort();
+
+    // Compare components
+    const expectedComponents = getComponentNames(expected.components);
+    const actualComponents = getComponentNames(actual.components);
+
+    const missingComponents = expectedComponents.filter(c => !actualComponents.includes(c));
+    const extraComponents = actualComponents.filter(c => !expectedComponents.includes(c));
+
+    const componentPropertyDiffs = {};
+
+    // Compare component properties
+    expected.components.forEach(expectedComponent => {
+        const actualComponent = actual.components.find(c => c.purl === expectedComponent.purl);
+        if (actualComponent) {
+            // Compare component properties
+            const propertyDiffs = [];
+            const propertiesToCompare = ['name', 'version', 'bom-ref', 'type', 'group', 'scope'];
+            
+            propertiesToCompare.forEach(prop => {
+                if (expectedComponent[prop] !== actualComponent[prop]) {
+                    propertyDiffs.push({
+                        property: prop,
+                        expected: expectedComponent[prop],
+                        actual: actualComponent[prop]
+                    });
+                }
+            });
+
+            if (propertyDiffs.length > 0) {
+                componentPropertyDiffs[expectedComponent.name] = propertyDiffs;
+            }
+        }
+    });
+
+    // Compare dependencies
+    const expectedDeps = expected.dependencies || [];
+    const actualDeps = actual.dependencies || [];
+
+    const missingDeps = expectedDeps.filter(ed => !actualDeps.some(ad => ad.ref === ed.ref));
+    const extraDeps = actualDeps.filter(ad => !expectedDeps.some(ed => ed.ref === ad.ref));
+
+    const dependencyDiffs = {};
+
+    // Compare dependencies for each component
+    expectedDeps.forEach(expectedDep => {
+        const actualDep = actualDeps.find(ad => ad.ref === expectedDep.ref);
+        if (actualDep) {
+            const missingDependsOn = (expectedDep.dependsOn || []).filter(d => !(actualDep.dependsOn || []).includes(d));
+            const extraDependsOn = (actualDep.dependsOn || []).filter(d => !(expectedDep.dependsOn || []).includes(d));
+
+            if (missingDependsOn.length > 0 || extraDependsOn.length > 0) {
+                dependencyDiffs[expectedDep.ref] = {
+                    missing: missingDependsOn,
+                    unexpected: extraDependsOn
+                };
+            }
+        }
+    });
+
+    // Perform assertions with meaningful error messages
+    if (missingComponents.length > 0) {
+        throw new Error(`Missing components in actual SBOM: ${missingComponents.join(', ')}`);
+    }
+    if (extraComponents.length > 0) {
+        throw new Error(`Unexpected components in actual SBOM: ${extraComponents.join(', ')}`);
+    }
+
+    Object.entries(componentPropertyDiffs).forEach(([component, diffs]) => {
+        const propertyErrors = diffs.map(diff => 
+            `Property '${diff.property}' has incorrect value. Expected: ${diff.expected || 'undefined'}, Actual: ${diff.actual || 'undefined'}`
+        );
+        throw new Error(`Component ${component} has property issues:\n${propertyErrors.join('\n')}`);
+    });
+
+    if (missingDeps.length > 0) {
+        throw new Error(`Missing dependencies in actual SBOM: ${missingDeps.map(d => d.ref).join(', ')}`);
+    }
+    if (extraDeps.length > 0) {
+        throw new Error(`Unexpected dependencies in actual SBOM: ${extraDeps.map(d => d.ref).join(', ')}`);
+    }
+
+    Object.entries(dependencyDiffs).forEach(([ref, diffs]) => {
+        if (diffs.missing.length > 0) {
+            throw new Error(`Dependency ${ref} is missing dependsOn: ${diffs.missing.join(', ')}`);
+        }
+        if (diffs.unexpected.length > 0) {
+            throw new Error(`Dependency ${ref} has unexpected dependsOn: ${diffs.unexpected.join(', ')}`);
+        }
+    });
+
+    // Compare metadata
+    const actualEcosystem = actual.metadata?.component?.ecosystem;
+    const expectedEcosystem = expected.metadata?.component?.ecosystem;
+    if (actualEcosystem !== expectedEcosystem) {
+        throw new Error(`Ecosystem mismatch. Expected: ${expectedEcosystem}, Actual: ${actualEcosystem}`);
+    }
+
+    const actualContentType = actual.metadata?.component?.contentType;
+    const expectedContentType = expected.metadata?.component?.contentType;
+    if (actualContentType !== expectedContentType) {
+        throw new Error(`Content type mismatch. Expected: ${expectedContentType}, Actual: ${actualContentType}`);
+    }
+} 

--- a/test/utils/sbom_utils.js
+++ b/test/utils/sbom_utils.js
@@ -5,112 +5,112 @@
  * @throws {Error} If the SBOMs don't match, with a descriptive error message
  */
 export function compareSboms(actualSbom, expectedSbom) {
-    // Parse the SBOMs if they're strings
-    const expected = typeof expectedSbom === 'string' ? JSON.parse(expectedSbom) : expectedSbom;
-    const actual = typeof actualSbom === 'string' ? JSON.parse(actualSbom) : actualSbom;
+	// Parse the SBOMs if they're strings
+	const expected = typeof expectedSbom === 'string' ? JSON.parse(expectedSbom) : expectedSbom;
+	const actual = typeof actualSbom === 'string' ? JSON.parse(actualSbom) : actualSbom;
 
-    // Helper function to get component names
-    const getComponentNames = (components) => components.map(c => c.name).sort();
+	// Helper function to get component names
+	const getComponentNames = (components) => components.map(c => c.name).sort();
 
-    // Compare components
-    const expectedComponents = getComponentNames(expected.components);
-    const actualComponents = getComponentNames(actual.components);
+	// Compare components
+	const expectedComponents = getComponentNames(expected.components);
+	const actualComponents = getComponentNames(actual.components);
 
-    const missingComponents = expectedComponents.filter(c => !actualComponents.includes(c));
-    const extraComponents = actualComponents.filter(c => !expectedComponents.includes(c));
+	const missingComponents = expectedComponents.filter(c => !actualComponents.includes(c));
+	const extraComponents = actualComponents.filter(c => !expectedComponents.includes(c));
 
-    const componentPropertyDiffs = {};
+	const componentPropertyDiffs = {};
 
-    // Compare component properties
-    expected.components.forEach(expectedComponent => {
-        const actualComponent = actual.components.find(c => c.purl === expectedComponent.purl);
-        if (actualComponent) {
-            // Compare component properties
-            const propertyDiffs = [];
-            const propertiesToCompare = ['name', 'version', 'bom-ref', 'type', 'group', 'scope'];
-            
-            propertiesToCompare.forEach(prop => {
-                if (expectedComponent[prop] !== actualComponent[prop]) {
-                    propertyDiffs.push({
-                        property: prop,
-                        expected: expectedComponent[prop],
-                        actual: actualComponent[prop]
-                    });
-                }
-            });
+	// Compare component properties
+	expected.components.forEach(expectedComponent => {
+		const actualComponent = actual.components.find(c => c.purl === expectedComponent.purl);
+		if (actualComponent) {
+			// Compare component properties
+			const propertyDiffs = [];
+			const propertiesToCompare = ['name', 'version', 'bom-ref', 'type', 'group', 'scope'];
 
-            if (propertyDiffs.length > 0) {
-                componentPropertyDiffs[expectedComponent.name] = propertyDiffs;
-            }
-        }
-    });
+			propertiesToCompare.forEach(prop => {
+				if (expectedComponent[prop] !== actualComponent[prop]) {
+					propertyDiffs.push({
+						property: prop,
+						expected: expectedComponent[prop],
+						actual: actualComponent[prop]
+					});
+				}
+			});
 
-    // Compare dependencies
-    const expectedDeps = expected.dependencies || [];
-    const actualDeps = actual.dependencies || [];
+			if (propertyDiffs.length > 0) {
+				componentPropertyDiffs[expectedComponent.name] = propertyDiffs;
+			}
+		}
+	});
 
-    const missingDeps = expectedDeps.filter(ed => !actualDeps.some(ad => ad.ref === ed.ref));
-    const extraDeps = actualDeps.filter(ad => !expectedDeps.some(ed => ed.ref === ad.ref));
+	// Compare dependencies
+	const expectedDeps = expected.dependencies || [];
+	const actualDeps = actual.dependencies || [];
 
-    const dependencyDiffs = {};
+	const missingDeps = expectedDeps.filter(ed => !actualDeps.some(ad => ad.ref === ed.ref));
+	const extraDeps = actualDeps.filter(ad => !expectedDeps.some(ed => ed.ref === ad.ref));
 
-    // Compare dependencies for each component
-    expectedDeps.forEach(expectedDep => {
-        const actualDep = actualDeps.find(ad => ad.ref === expectedDep.ref);
-        if (actualDep) {
-            const missingDependsOn = (expectedDep.dependsOn || []).filter(d => !(actualDep.dependsOn || []).includes(d));
-            const extraDependsOn = (actualDep.dependsOn || []).filter(d => !(expectedDep.dependsOn || []).includes(d));
+	const dependencyDiffs = {};
 
-            if (missingDependsOn.length > 0 || extraDependsOn.length > 0) {
-                dependencyDiffs[expectedDep.ref] = {
-                    missing: missingDependsOn,
-                    unexpected: extraDependsOn
-                };
-            }
-        }
-    });
+	// Compare dependencies for each component
+	expectedDeps.forEach(expectedDep => {
+		const actualDep = actualDeps.find(ad => ad.ref === expectedDep.ref);
+		if (actualDep) {
+			const missingDependsOn = (expectedDep.dependsOn || []).filter(d => !(actualDep.dependsOn || []).includes(d));
+			const extraDependsOn = (actualDep.dependsOn || []).filter(d => !(expectedDep.dependsOn || []).includes(d));
 
-    // Perform assertions with meaningful error messages
-    if (missingComponents.length > 0) {
-        throw new Error(`Missing components in actual SBOM: ${missingComponents.join(', ')}`);
-    }
-    if (extraComponents.length > 0) {
-        throw new Error(`Unexpected components in actual SBOM: ${extraComponents.join(', ')}`);
-    }
+			if (missingDependsOn.length > 0 || extraDependsOn.length > 0) {
+				dependencyDiffs[expectedDep.ref] = {
+					missing: missingDependsOn,
+					unexpected: extraDependsOn
+				};
+			}
+		}
+	});
 
-    Object.entries(componentPropertyDiffs).forEach(([component, diffs]) => {
-        const propertyErrors = diffs.map(diff => 
-            `Property '${diff.property}' has incorrect value. Expected: ${diff.expected || 'undefined'}, Actual: ${diff.actual || 'undefined'}`
-        );
-        throw new Error(`Component ${component} has property issues:\n${propertyErrors.join('\n')}`);
-    });
+	// Perform assertions with meaningful error messages
+	if (missingComponents.length > 0) {
+		throw new Error(`Missing components in actual SBOM: ${missingComponents.join(', ')}`);
+	}
+	if (extraComponents.length > 0) {
+		throw new Error(`Unexpected components in actual SBOM: ${extraComponents.join(', ')}`);
+	}
 
-    if (missingDeps.length > 0) {
-        throw new Error(`Missing dependencies in actual SBOM: ${missingDeps.map(d => d.ref).join(', ')}`);
-    }
-    if (extraDeps.length > 0) {
-        throw new Error(`Unexpected dependencies in actual SBOM: ${extraDeps.map(d => d.ref).join(', ')}`);
-    }
+	Object.entries(componentPropertyDiffs).forEach(([component, diffs]) => {
+		const propertyErrors = diffs.map(diff =>
+			`Property '${diff.property}' has incorrect value. Expected: ${diff.expected || 'undefined'}, Actual: ${diff.actual || 'undefined'}`
+		);
+		throw new Error(`Component ${component} has property issues:\n${propertyErrors.join('\n')}`);
+	});
 
-    Object.entries(dependencyDiffs).forEach(([ref, diffs]) => {
-        if (diffs.missing.length > 0) {
-            throw new Error(`Dependency ${ref} is missing dependsOn: ${diffs.missing.join(', ')}`);
-        }
-        if (diffs.unexpected.length > 0) {
-            throw new Error(`Dependency ${ref} has unexpected dependsOn: ${diffs.unexpected.join(', ')}`);
-        }
-    });
+	if (missingDeps.length > 0) {
+		throw new Error(`Missing dependencies in actual SBOM: ${missingDeps.map(d => d.ref).join(', ')}`);
+	}
+	if (extraDeps.length > 0) {
+		throw new Error(`Unexpected dependencies in actual SBOM: ${extraDeps.map(d => d.ref).join(', ')}`);
+	}
 
-    // Compare metadata
-    const actualEcosystem = actual.metadata?.component?.ecosystem;
-    const expectedEcosystem = expected.metadata?.component?.ecosystem;
-    if (actualEcosystem !== expectedEcosystem) {
-        throw new Error(`Ecosystem mismatch. Expected: ${expectedEcosystem}, Actual: ${actualEcosystem}`);
-    }
+	Object.entries(dependencyDiffs).forEach(([ref, diffs]) => {
+		if (diffs.missing.length > 0) {
+			throw new Error(`Dependency ${ref} is missing dependsOn: ${diffs.missing.join(', ')}`);
+		}
+		if (diffs.unexpected.length > 0) {
+			throw new Error(`Dependency ${ref} has unexpected dependsOn: ${diffs.unexpected.join(', ')}`);
+		}
+	});
 
-    const actualContentType = actual.metadata?.component?.contentType;
-    const expectedContentType = expected.metadata?.component?.contentType;
-    if (actualContentType !== expectedContentType) {
-        throw new Error(`Content type mismatch. Expected: ${expectedContentType}, Actual: ${actualContentType}`);
-    }
-} 
+	// Compare metadata
+	const actualEcosystem = actual.metadata?.component?.ecosystem;
+	const expectedEcosystem = expected.metadata?.component?.ecosystem;
+	if (actualEcosystem !== expectedEcosystem) {
+		throw new Error(`Ecosystem mismatch. Expected: ${expectedEcosystem}, Actual: ${actualEcosystem}`);
+	}
+
+	const actualContentType = actual.metadata?.component?.contentType;
+	const expectedContentType = expected.metadata?.component?.contentType;
+	if (actualContentType !== expectedContentType) {
+		throw new Error(`Content type mismatch. Expected: ${expectedContentType}, Actual: ${actualContentType}`);
+	}
+}


### PR DESCRIPTION
## Description

Refactor how the Gradle dependencies are resolved because as the full tree is available in both component and stack analysis we can use the right trees instead of just the `api / implementation` listings. This helps resolving the correct versions.

With that it is also possible to include the correct scope (required / optional) to the sbom

**Related issues (if any):** 

- fixes: #226 
- fixes: #227 
- fixes #228 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

Also includes a fix for running the unit tests.
