### PR TITLE
feat: support passing additional arguments to maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,14 @@ It's also possible to use the lightweight Python PIP utility [pipdeptree](https:
 #### Toggle Red Hat Trusted Content recommendations
 Both the HTML-based report and JSON response will by default contain recommendations for migrating to Red Hat-based Trusted Content repositories. This feature can be disabled by setting `EXHORT_RECOMMENDATIONS_ENABLED` to 'false' via environment variables or options.
 
+#### Additional CLI arguments
+For some ecosystems we support passing additional CLI arguments to the underlying tools. The following table outlines the supported ecosystems and the environment variable/option that configures this. Note that the arguments are expected to be in the format of a JSON array.
+
+|Ecosystem|Key            |
+|---------|---------------|
+|Maven    |EXHORT_MVN_ARGS|
+
+
 <!-- Badge links -->
 [0]: https://img.shields.io/github/v/release/trustification/exhort-javascript-api?color=green&label=latest
 [1]: https://img.shields.io/github/v/release/trustification/exhort-javascript-api?color=yellow&include_prereleases&label=early-access


### PR DESCRIPTION
## Description

Adds support for passing additional CLI args to maven invocations. The env var/option must be passed as a JSON array with each arg as an individual string. This is as opposed to being e.g. comma delimited, as it avoids ambiguity if the comma character is part of the args as opposed to a delimiter 

**Related issues (if any):** https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/520

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
