### PR TITLE
fix: use & pass down opts for getCustom in imageAnalysis

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
+
       - name: get Python location
         id: python-location
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 			},
 			"devDependencies": {
 				"@babel/core": "^7.23.2",
-				"@trustification/exhort-api-spec": "^1.0.13",
+				"@trustification/exhort-api-spec": "^1.0.18",
 				"@types/node": "^20.17.30",
 				"@types/which": "^3.0.4",
 				"babel-plugin-rewire": "^1.2.0",
@@ -863,9 +863,9 @@
 			"license": "(Unlicense OR Apache-2.0)"
 		},
 		"node_modules/@trustification/exhort-api-spec": {
-			"version": "1.0.13",
-			"resolved": "https://npm.pkg.github.com/download/@trustification/exhort-api-spec/1.0.13/5ad3fc6d7abfd81745d784dc112dbf7c4ee71ea8",
-			"integrity": "sha512-wTDPOWUTvPHN+PkLoVGYxAfCY/ALB7xi9XHIufvI88y4aeW+UDcjaRINwEUl9fupG2VJQ0Ory+uEeW1BSBIkDQ==",
+			"version": "1.0.18",
+			"resolved": "https://npm.pkg.github.com/download/@trustification/exhort-api-spec/1.0.18/b7f6dc02d979899c009edbc0bf3d9bdee137f151",
+			"integrity": "sha512-ft9oRpItc9LDe/fzcrQiLYJBd3Tpmx0nMl9VMMSfajVDuy3Ot+vMqI3OvhytnzlSb3rY8UUg3+m7xqhi4U/zJw==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.2",
-		"@trustification/exhort-api-spec": "^1.0.13",
+		"@trustification/exhort-api-spec": "^1.0.18",
 		"@types/node": "^20.17.30",
 		"@types/which": "^3.0.4",
 		"babel-plugin-rewire": "^1.2.0",

--- a/src/analysis.js
+++ b/src/analysis.js
@@ -156,8 +156,8 @@ async function requestComponent(provider, manifest, url, opts = {}) {
 async function requestImages(imageRefs, url, html = false, opts = {}) {
 	const imageSboms = {}
 	for (const image of imageRefs) {
-		const parsedImageRef = parseImageRef(image)
-		imageSboms[parsedImageRef.getPackageURL().toString()] = generateImageSBOM(parsedImageRef)
+		const parsedImageRef = parseImageRef(image, opts)
+		imageSboms[parsedImageRef.getPackageURL().toString()] = generateImageSBOM(parsedImageRef, opts)
 	}
 
 	const finalUrl = new URL(`${url}/api/v4/batch-analysis`);

--- a/src/oci_image/images.js
+++ b/src/oci_image/images.js
@@ -216,24 +216,25 @@ export class ImageRef {
 	/**
 	 * @param {string} image
 	 * @param {string} [platform]
+	 * @param {import("index.js").Options} [opts={}]
 	 */
-	constructor(image, platform) {
+	constructor(image, platform, opts) {
 		this.image = new Image(image);
 
 		if (platform != null) {
 			this.platform = Platform.fromString(platform);
 		}
 
-		this.checkImageDigest();
+		this.checkImageDigest(opts);
 	}
 
 	/**
 	 * @private
 	 */
-	checkImageDigest() {
+	checkImageDigest(opts) {
 		if (this.image.digest == null) {
 			try {
-				const digests = getImageDigests(this);
+				const digests = getImageDigests(this, opts);
 				if (digests.size === 0) {
 					throw new Error("Failed to get any image digest");
 				}
@@ -241,7 +242,7 @@ export class ImageRef {
 					this.image.digest = digests[Platform.EMPTY.toString()];
 				} else {
 					if (this.platform == null) {
-						this.platform = getImagePlatform();
+						this.platform = getImagePlatform(opts);
 					}
 					if (this.platform == null) {
 						throw new Error(`Failed to get image platform for image digest`);

--- a/src/tools.js
+++ b/src/tools.js
@@ -13,16 +13,12 @@ export const RegexNotToBeLogged = /EXHORT_.*_TOKEN|ex-.*-token/
 export function logValueFromObjects(key,opts, defValue) {
 	if(key in opts) {
 		console.log(`value of option with key ${key} = ${opts[key]} ${EOL}`)
-	}
-	else
-	{
+	} else {
 		console.log(`key ${key} doesn't exists on opts object ${EOL}`)
 	}
 	if(key in process.env) {
 		console.log(`value of environment variable ${key} = ${process.env[key]} ${EOL}`)
-	}
-	else
-	{
+	} else {
 		console.log(`environment variable ${key} doesn't exists ${EOL}`)
 	}
 	console.log(`default value for ${key} = ${defValue} ${EOL}`)

--- a/test/providers/tst_manifests/image/httpd:2.4.49.json
+++ b/test/providers/tst_manifests/image/httpd:2.4.49.json
@@ -11727,6 +11727,10 @@
                 }
             ],
             "properties": [
+				{
+					"name": "syft:distro:extendedSupport",
+					"value": "false"
+				},
                 {
                     "name": "syft:distro:id",
                     "value": "debian"

--- a/test/providers/tst_manifests/image/httpd:2.4.49^^amd64.json
+++ b/test/providers/tst_manifests/image/httpd:2.4.49^^amd64.json
@@ -11727,6 +11727,10 @@
                 }
             ],
             "properties": [
+				{
+					"name": "syft:distro:extendedSupport",
+					"value": "false"
+				},
                 {
                     "name": "syft:distro:id",
                     "value": "debian"

--- a/test/providers/tst_manifests/image/httpd@sha256:4b5cb7697fea2aa6d398504c381b693a54ae9ad5e6317fcdbb7a2d9b8c3b1364.json
+++ b/test/providers/tst_manifests/image/httpd@sha256:4b5cb7697fea2aa6d398504c381b693a54ae9ad5e6317fcdbb7a2d9b8c3b1364.json
@@ -11727,6 +11727,10 @@
                 }
             ],
             "properties": [
+				{
+					"name": "syft:distro:extendedSupport",
+					"value": "false"
+				},
                 {
                     "name": "syft:distro:id",
                     "value": "debian"


### PR DESCRIPTION
## Description

image analysis was still using `process.env` in a lot of places such as for using EXHORT_IMAGE_PLATFORM. This is a holdover from when this was still the externally executed JAR file, where reading from env was the correct approach. This PR updates this translated code to use `getCustom` like other parts of the library, and passing `opts` down correctly to all the relevant sections

**Related issues (if any):** 

- fixes: https://issues.redhat.com/browse/TC-2797

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

