### PR TITLE
fix: properly handle go.mod files with no dependencies

### DIFF
--- a/test/providers/golang_gomodules.test.js
+++ b/test/providers/golang_gomodules.test.js
@@ -23,7 +23,8 @@ suite('testing the golang-go-modules data provider', () => {
 		"go_mod_no_ignore",
 		"go_mod_with_ignore",
 		"go_mod_test_ignore",
-		"go_mod_with_all_ignore"
+		"go_mod_with_all_ignore",
+		"go_mod_empty"
 	].forEach(testCase => {
 		let scenario = testCase.replace('go_mod_', '').replaceAll('_', ' ')
 		test(`verify go.mod sbom provided for stack analysis with scenario ${scenario}`, () => {

--- a/test/providers/tst_manifests/golang/go_mod_empty/expected_sbom_component_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_empty/expected_sbom_component_analysis.json
@@ -1,0 +1,27 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "group": "github.com/sample",
+            "name": "empty-module",
+            "version": "v0.0.0",
+            "purl": "pkg:golang/github.com/sample/empty-module@v0.0.0",
+            "type": "application",
+            "bom-ref": "pkg:golang/github.com/sample/empty-module@v0.0.0"
+        }
+    },
+    "components": [
+        {
+            "group": "github.com/sample",
+            "name": "empty-module",
+            "version": "v0.0.0",
+            "purl": "pkg:golang/github.com/sample/empty-module@v0.0.0",
+            "type": "application",
+            "bom-ref": "pkg:golang/github.com/sample/empty-module@v0.0.0"
+        }
+    ],
+    "dependencies": []
+}

--- a/test/providers/tst_manifests/golang/go_mod_empty/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_empty/expected_sbom_stack_analysis.json
@@ -1,0 +1,52 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "group": "github.com/sample",
+            "name": "empty-module",
+            "version": "v0.0.0",
+            "purl": "pkg:golang/github.com/sample/empty-module@v0.0.0",
+            "type": "application",
+            "bom-ref": "pkg:golang/github.com/sample/empty-module@v0.0.0"
+        }
+    },
+    "components": [
+        {
+            "group": "github.com/sample",
+            "name": "empty-module",
+            "version": "v0.0.0",
+            "purl": "pkg:golang/github.com/sample/empty-module@v0.0.0",
+            "type": "application",
+            "bom-ref": "pkg:golang/github.com/sample/empty-module@v0.0.0"
+        },
+        {
+            "name": "go",
+            "version": "1.24",
+            "purl": "pkg:golang/go@1.24",
+            "type": "library",
+            "bom-ref": "pkg:golang/go@1.24"
+        },
+        {
+            "name": "toolchain",
+            "version": "go1.24",
+            "purl": "pkg:golang/toolchain@go1.24",
+            "type": "library",
+            "bom-ref": "pkg:golang/toolchain@go1.24"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:golang/go@1.24",
+            "dependsOn": [
+                "pkg:golang/toolchain@go1.24"
+            ]
+        },
+        {
+            "ref": "pkg:golang/toolchain@go1.24",
+            "dependsOn": []
+        }
+    ]
+}

--- a/test/providers/tst_manifests/golang/go_mod_empty/go.mod
+++ b/test/providers/tst_manifests/golang/go_mod_empty/go.mod
@@ -1,0 +1,3 @@
+module github.com/sample/empty-module
+
+go 1.24


### PR DESCRIPTION
## Description

If go.mod file is empty `go mod graph` would return only one line (containing `@go` that we filter out), which would cause an exception when trying to determine the root module. Instead we can use `go mod edit -json` to get the root module from the following output:

```json
{
        "Module": {
                "Path": "github.com/sample/empty-module"
        },
        "Go": "1.24",
        "Require": null,
        "Exclude": null,
        "Replace": null,
        "Retract": null,
        "Tool": null
}
```

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
