### PR TITLE
fix: allow ignored packages without version

### DIFF
--- a/src/providers/python_pip.js
+++ b/src/providers/python_pip.js
@@ -95,6 +95,9 @@ function splitToNameVersion(nameVersion) {
 	}
 	const regex = /[^\w\s-_]/g;
 	let endIndex = nameVersion.search(regex);
+	if(endIndex === -1) {
+		return [nameVersion.trim()]
+	}
 	result.push(nameVersion.substring(0, endIndex).trim())
 	return result;
 }


### PR DESCRIPTION
## Description

When the python packages does not define a version the stack analysis returns a confusing error:

```
Error: Invalid purl: "name" is a required field.
```

It should allow parsing lines without version because they default to the latest version.

**Related issues (if any):** 

- fixes: [TC-2802](https://issues.redhat.com/browse/TC-2802)

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

