### PR TITLE
fix: correctly fallback to podman if docker hostinfo returns nothing

### DIFF
--- a/src/oci_image/utils.js
+++ b/src/oci_image/utils.js
@@ -302,7 +302,7 @@ function podmanGetVariant(opts = {}) {
  * @returns {string} - The information
  */
 function dockerPodmanInfo(dockerSupplier, podmanSupplier, opts = {}) {
-	return dockerSupplier(opts) ?? podmanSupplier(opts);
+	return dockerSupplier(opts) || podmanSupplier(opts);
 }
 
 /**


### PR DESCRIPTION
## Description

`hostInfo` returns an empty string if the string isnt found in `docker/podman info`. `??` won't fallback to checking with podman as this operates on nullables, not truthiness

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
